### PR TITLE
Fix: asynchronous logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ FROM phusion/baseimage:jammy-1.0.1 as base
 USER $DOCKER_UID:$DOCKER_GID
 ENV HOME="/home/dev"
 RUN add-apt-repository --yes ppa:deadsnakes/ppa
-
-# TODO: handle user here...
-
-# TODO: reduce this to the minimum...
 RUN --mount=type=cache,target=/var/cache/apt  \
     apt-get -y update && \
     apt-get -y install \

--- a/neo4j-app/neo4j_app/app/named_entities.py
+++ b/neo4j-app/neo4j_app/app/named_entities.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, Request
@@ -7,6 +8,9 @@ from neo4j_app.core import AppConfig
 from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.core.imports import import_named_entities
 from neo4j_app.core.objects import IncrementalImportRequest, IncrementalImportResponse
+from neo4j_app.core.utils.logging import log_elapsed_time_cm
+
+logger = logging.getLogger(__name__)
 
 NE_TAG = "Named entities"
 _NE_IMPORT_SUM = "Import named entities from elasticsearch to neo4j"
@@ -76,16 +80,20 @@ def named_entities_router() -> APIRouter:
     ) -> IncrementalImportResponse:
         neo4j_sess = request.state.neo4j_session
         config: AppConfig = request.app.state.config
-        return await import_named_entities(
-            query=payload.query,
-            neo4j_session=neo4j_sess,
-            es_client=es_client,
-            neo4j_import_dir=Path(config.neo4j_import_dir),
-            neo4j_import_prefix=config.neo4j_import_prefix,
-            keep_alive=config.es_keep_alive,
-            doc_type_field=config.es_doc_type_field,
-            # TODO: take this one from the payload
-            concurrency=es_client.max_concurrency,
-        )
+        with log_elapsed_time_cm(
+            logger, logging.INFO, "Imported named entities in {elapsed_time} !"
+        ):
+            res = await import_named_entities(
+                query=payload.query,
+                neo4j_session=neo4j_sess,
+                es_client=es_client,
+                neo4j_import_dir=Path(config.neo4j_import_dir),
+                neo4j_import_prefix=config.neo4j_import_prefix,
+                keep_alive=config.es_keep_alive,
+                doc_type_field=config.es_doc_type_field,
+                # TODO: take this one from the payload
+                concurrency=es_client.max_concurrency,
+            )
+        return res
 
     return router

--- a/neo4j-app/neo4j_app/core/elasticsearch/client.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/client.py
@@ -26,7 +26,6 @@ from neo4j_app.core.elasticsearch.utils import (
     match_all,
 )
 from neo4j_app.core.neo4j import write_neo4j_csv
-from neo4j_app.core.utils.logging import log_elapsed_time
 
 logger = logging.getLogger(__name__)
 
@@ -126,9 +125,6 @@ class ESClient(AsyncElasticsearch):
             if pit_id is not None:
                 await self.close_point_in_time(body={ID: pit_id})
 
-    @log_elapsed_time(
-        logger, logging.DEBUG, "Exported ES query to neo4j csv in {elapsed_time} !"
-    )
     async def write_concurrently_neo4j_csv(
         self,
         query: Optional[Mapping[str, Any]],


### PR DESCRIPTION
# Bug description

Some logs were time some operations were implemented using the `@log_elapsed_time` decorator. However when used on an `async` coroutine, this decorator does not really time the elapsed time but rather the time to return the `Future` which is generally close to `0` and not relevant.

# Changes

## `datashare-extension-neo4j/neo4j-app`

### Changed
- Replaced logging on coroutines decorated with `@log_elapsed_time` by the `@log_elapsed_time_cm` context manager