### PR TITLE
feature: as a developer I should be able to migrate the `neo4j` DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ After building the app:
 ./neo4j run -p neo4j_app
 ```
 
+this will use the default app configuration. However is to provide the path to a 
+[Datashare](https://github.com/ICIJ/datashare) `properties`. The location of this file can be found in Datashare's 
+settings. 
+
 and then navigate to [http://localhost/8080/docs](http://localhost/8080/docs)
 
 ### Start/stop test services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@ services:
       target: elasticsearch
     environment:
       - discovery.type=single-node
-      - http.port=${ELASTICSEARCH_PORT}
+      - http.port=9200
     ports:
-      - ${ELASTICSEARCH_PORT}:${ELASTICSEARCH_PORT}
+      - ${ELASTICSEARCH_PORT}:9200
     healthcheck:
-      test: [ "CMD", "curl", "http://localhost:$ELASTICSEARCH_PORT" ]
+      test: [ "CMD", "curl", "http://localhost:9200" ]
       interval: 3s
       timeout: 1s
       retries: 10
@@ -42,8 +42,8 @@ services:
       retries: 10
       start_period: 20s
     ports:
-      - 7474:7474
-      - 7687:7687
+      - 7475:7474
+      - 7688:7687
     volumes:
       - type: bind
         source: .data/neo4j/import/

--- a/neo4j
+++ b/neo4j
@@ -11,11 +11,7 @@ function _export_global_variables() {
     export DOCKER_UID
     DOCKER_GID="$(id -g)"
     export DOCKER_GID
-    if [ -z "$_ELASTICSEARCH_PORT" ]; then
-        export ELASTICSEARCH_PORT="9200"
-    else
-        export ELASTICSEARCH_PORT=$_ELASTICSEARCH_PORT
-    fi
+    export ELASTICSEARCH_PORT=9201
     export NEO4J_VERSION=4.4.17
     export TEST_APP_PORT=8002
     local archi
@@ -314,7 +310,6 @@ Please run ./neo4j format"
 function _main() {
     PROJECT=
     PROJECTS=
-    _ELASTICSEARCH_PORT=
     OPENSEARCH_SUPPORT=
 
     # Define sub projects here
@@ -353,9 +348,6 @@ function _main() {
                     VALUE_ARG="${!j}"
                     if [[ "$TYPE_ARG" == "-p" ]]; then
                         _parse_project_flag $VALUE_ARG
-                        SKIP_NEXT_TYPE_ARG=true
-                    elif [[ "$TYPE_ARG" == "--elasticsearch-port" ]]; then
-                        _ELASTICSEARCH_PORT=$VALUE_ARG
                         SKIP_NEXT_TYPE_ARG=true
                     elif [[ "$TYPE_ARG" == "--opensearch-support" ]]; then
                         OPENSEARCH_SUPPORT=true

--- a/neo4j-app/neo4j_app/__init__.py
+++ b/neo4j-app/neo4j_app/__init__.py
@@ -1,6 +1,3 @@
-import importlib.metadata
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).parent
-
-__version__ = importlib.metadata.version(__package__)

--- a/neo4j-app/neo4j_app/__init__.py
+++ b/neo4j-app/neo4j_app/__init__.py
@@ -1,3 +1,6 @@
+import importlib.metadata
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).parent
+
+__version__ = importlib.metadata.version(__package__)

--- a/neo4j-app/neo4j_app/app/utils.py
+++ b/neo4j-app/neo4j_app/app/utils.py
@@ -115,7 +115,7 @@ async def migrate_app_db(app: FastAPI):
                 sess,
                 registry=MIGRATIONS,
                 timeout_s=config.neo4j_app_migration_timeout_s,
-                wait_s=config.neo4j_app_migration_wait_s,
+                throttle_s=config.neo4j_app_migration_throttle_s,
             )
 
 

--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -4,7 +4,7 @@ DOC_CONTENT_TYPE = "contentType"
 DOC_DIRNAME = "dirname"
 DOC_ID = "id"
 DOC_EXTRACTION_DATE = "extractionDate"
-DOC_LABEL = "Document"
+DOC_NODE = "Document"
 DOC_PATH = "path"
 DOC_ROOT_ID = "rootId"
 DOC_COLUMNS = {
@@ -17,6 +17,13 @@ DOC_COLUMNS = {
     DOC_PATH,
 }
 
+MIGRATION_COMPLETED = "completed"
+MIGRATION_LABEL = "label"
+MIGRATION_NODE = "Migration"
+MIGRATION_STARTED = "started"
+MIGRATION_STATUS = "status"
+MIGRATION_VERSION = "version"
+
 NE_OFFSET_SPLITCHAR = ":"
 
 # TODO: replicate other named entities attributes
@@ -28,7 +35,7 @@ NE_EXTRACTOR_LANG = "extractorLanguage"
 NE_MENTION = "mention"
 NE_MENTION_NORM = "mentionNorm"
 NE_MENTION_NORM_TEXT_LENGTH = "mentionNormTextLength"
-NE_LABEL = "NamedEntity"
+NE_NODE = "NamedEntity"
 NE_OFFSETS = "offsets"
 NE_COLUMNS = {
     NE_ID,

--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -42,7 +42,7 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     neo4j_app_host: str = "127.0.0.1"
     neo4j_app_log_level: str = "INFO"
     neo4j_app_migration_timeout_s: float = 60 * 5
-    neo4j_app_migration_wait_s: float = 1
+    neo4j_app_migration_throttle_s: float = 1
     neo4j_app_name: str = "neo4j app"
     neo4j_app_port: int = 8080
     neo4j_app_syslog_facility: Optional[str] = None

--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -41,6 +41,8 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     es_keep_alive: str = "1m"
     neo4j_app_host: str = "127.0.0.1"
     neo4j_app_log_level: str = "INFO"
+    neo4j_app_migration_timeout_s: float = 60 * 5
+    neo4j_app_migration_wait_s: float = 1
     neo4j_app_name: str = "neo4j app"
     neo4j_app_port: int = 8080
     neo4j_app_syslog_facility: Optional[str] = None

--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -53,13 +53,14 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     neo4j_import_prefix: Optional[str] = None
     neo4j_port: int = 7687
     neo4j_project: str
+    force_migrations: bool = False
 
     # Ugly but hard to do differently if we want to avoid to retrieve the config on a
     # per request basis using FastApi dependencies...
     _global: Optional[AppConfig] = None
 
     @classmethod
-    def from_java_properties(cls, file: TextIO) -> AppConfig:
+    def from_java_properties(cls, file: TextIO, **kwargs) -> AppConfig:
         parser = ConfigParser(
             allow_no_value=True,
             strict=True,
@@ -76,6 +77,7 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     """
         parser.read_string(section_str)
         config_dict = dict(parser[section_name].items())
+        config_dict.update(kwargs)
         config_dict = _sanitize_values(config_dict)
         config = AppConfig.parse_obj(config_dict.items())
         return config

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -4,6 +4,16 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, TextIO, Tuple
+from .migrations import Migration
+from .migrations.migrate import migrate_db_schema, MigrationError
+from .migrations.migrations import create_migration_unique_constraint_tx
+
+FIRST_MIGRATION = Migration(
+    version="0.1.0",
+    label="Create migration index and constraints",
+    migration_fn=create_migration_unique_constraint_tx,
+)
+MIGRATIONS = [FIRST_MIGRATION]
 
 
 def get_neo4j_csv_writer(f: TextIO, header: List[str]) -> csv.DictWriter:

--- a/neo4j-app/neo4j_app/core/neo4j/documents.py
+++ b/neo4j-app/neo4j_app/core/neo4j/documents.py
@@ -9,7 +9,7 @@ from neo4j_app.constants import (
     DOC_DIRNAME,
     DOC_EXTRACTION_DATE,
     DOC_ID,
-    DOC_LABEL,
+    DOC_NODE,
     DOC_PATH,
     DOC_ROOT_ID,
 )
@@ -25,7 +25,7 @@ async def import_documents_from_csv_tx(
     #  have route to clean the DB and start fresh
     # TODO: add an index on document id
     query = f"""LOAD CSV WITH HEADERS FROM 'file:///{neo4j_import_path}' AS row
-MERGE (doc:{DOC_LABEL} {{{DOC_ID}: row.{DOC_ID}}})
+MERGE (doc:{DOC_NODE} {{{DOC_ID}: row.{DOC_ID}}})
 ON CREATE
     SET
         doc.{DOC_CONTENT_TYPE} = row.{DOC_CONTENT_TYPE},
@@ -55,7 +55,7 @@ async def documents_ids_tx(tx: neo4j.AsyncTransaction) -> List[str]:
 
 
 def document_ids_query() -> str:
-    query = f"""MATCH (doc:{DOC_LABEL})
+    query = f"""MATCH (doc:{DOC_NODE})
 RETURN doc.{DOC_ID} as {DOC_ID}
 """
     return query

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/__init__.py
@@ -1,0 +1,1 @@
+from .migrate import Migration

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/__init__.py
@@ -1,1 +1,1 @@
-from .migrate import Migration
+from .migrate import Migration, delete_all_migrations_tx

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -167,7 +167,7 @@ async def migrate_db_schema(
     registry: MigrationRegistry,
     *,
     timeout_s: float,
-    wait_s: float,
+    throttle_s: float,
 ):
     start = datetime.now()
     if not registry:
@@ -187,9 +187,9 @@ async def migrate_db_schema(
             logger.info(
                 "Found that %s is in progress, waiting for %s seconds...",
                 in_progress[0].label,
-                wait_s,
+                throttle_s,
             )
-            await asyncio.sleep(wait_s)
+            await asyncio.sleep(throttle_s)
             continue
         done = [m for m in migrations if m.status is MigrationStatus.DONE]
         if done:
@@ -206,7 +206,7 @@ async def migrate_db_schema(
                 "Migration %s has just started somewhere else, "
                 " waiting for %s seconds...",
                 todo[0].label,
-                wait_s,
+                throttle_s,
             )
-            await asyncio.sleep(wait_s)
+            await asyncio.sleep(throttle_s)
             continue

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Coroutine
+from datetime import datetime
+from distutils.version import StrictVersion
+from enum import Enum, unique
+from typing import Any, Callable, List, Optional, Sequence
+
+import neo4j
+from neo4j.exceptions import ConstraintError
+
+from neo4j_app.constants import (
+    MIGRATION_COMPLETED,
+    MIGRATION_LABEL,
+    MIGRATION_NODE,
+    MIGRATION_STARTED,
+    MIGRATION_STATUS,
+    MIGRATION_VERSION,
+)
+from neo4j_app.core.utils.pydantic import NoEnumModel
+
+logger = logging.getLogger(__name__)
+
+MigrationFn = Callable[[neo4j.AsyncTransaction], Coroutine]
+
+_MIGRATION_TIMEOUT_MSG = """Migration timeout expired !
+Please check that a migration is indeed in progress. If the application is in a \
+deadlock restart it forcing the migration index cleanup."""
+
+
+class MigrationError(RuntimeError):
+    pass
+
+
+@unique
+class MigrationStatus(str, Enum):
+    IN_PROGRESS = "IN_PROGRESS"
+    DONE = "DONE"
+
+
+class MigrationVersion(StrictVersion):
+    @classmethod
+    def __get_validators__(cls):
+        def validator(v: Any) -> MigrationVersion:
+            if isinstance(v, (str, MigrationVersion)):
+                return MigrationVersion(v)
+            raise ValueError(
+                f"Must be a {MigrationVersion.__name__} or a {str.__name__}, "
+                f"found {type(v)}"
+            )
+
+        yield validator
+
+
+class _BaseMigration(NoEnumModel):
+    version: MigrationVersion
+    label: str
+    status: MigrationStatus = MigrationStatus.IN_PROGRESS
+
+
+class Neo4jMigration(_BaseMigration):
+    version: MigrationVersion
+    label: str
+    started: datetime
+    completed: Optional[datetime] = None
+
+    @classmethod
+    def from_neo4j(cls, record: neo4j.Record, key="migration") -> Neo4jMigration:
+        migration = dict(record[key])
+        if "started" in migration:
+            migration["started"] = migration["started"].to_native()
+        if "completed" in migration:
+            migration["completed"] = migration["completed"].to_native()
+        return Neo4jMigration(**migration)
+
+
+class Migration(_BaseMigration):
+    migration_fn: MigrationFn
+
+
+MigrationRegistry: Sequence[Migration]
+
+
+async def _migration_wrapper(neo4j_session: neo4j.AsyncSession, migration: Migration):
+    # Note: all migrations.py should be carefully test otherwise they will lock
+    # the DB...
+
+    # Lock the DB first, raising in case a migration already exists
+    logger.debug("Trying to run migration %s...", migration.label)
+    await neo4j_session.execute_write(
+        create_migration_tx,
+        migration_version=str(migration.version),
+        migration_label=migration.label,
+    )
+    # Then run to migration
+    logger.debug("Acquired write lock for %s !", migration.label)
+    await neo4j_session.execute_write(migration.migration_fn)
+    # Finally free the lock
+    await neo4j_session.execute_write(
+        complete_migration_tx, version=str(migration.version)
+    )
+    logger.debug("Marked %s as complete !", migration.label)
+
+
+async def create_migration_tx(
+    tx: neo4j.AsyncTransaction,
+    *,
+    migration_version: str,
+    migration_label: str,
+) -> Neo4jMigration:
+    query = f"""CREATE (m:{MIGRATION_NODE} {{
+    {MIGRATION_LABEL}: $label,
+    {MIGRATION_VERSION}: $version,
+    {MIGRATION_STATUS}: $status,
+    {MIGRATION_STARTED}:  $started
+}})
+RETURN m as migration"""
+    res = await tx.run(
+        query,
+        label=migration_label,
+        version=migration_version,
+        status=MigrationStatus.IN_PROGRESS.value,
+        started=datetime.now(),
+    )
+    m = await res.single()
+    m = Neo4jMigration.from_neo4j(m, key="migration")
+    return m
+
+
+async def complete_migration_tx(
+    tx: neo4j.AsyncTransaction, version: str
+) -> Neo4jMigration:
+    query = f"""MATCH (m:{MIGRATION_NODE} {{ {MIGRATION_VERSION}: $version }})
+SET m += {{ {MIGRATION_STATUS}: $status, {MIGRATION_COMPLETED}: $completed }} 
+RETURN m as migration"""
+    res = await tx.run(
+        query,
+        version=version,
+        status=MigrationStatus.DONE.value,
+        completed=datetime.now(),
+    )
+    m = await res.single()
+    m = Neo4jMigration.from_neo4j(m, key="migration")
+    return m
+
+
+async def migrations_tx(tx: neo4j.AsyncTransaction) -> List[Neo4jMigration]:
+    query = f"""MATCH (m:{MIGRATION_NODE})
+RETURN m as migration
+"""
+    res = await tx.run(query)
+    migrations = [Neo4jMigration.from_neo4j(rec, key="migration") async for rec in res]
+    return migrations
+
+
+async def migrate_db_schema(
+    neo4j_session: neo4j.AsyncSession,
+    registry: MigrationRegistry,
+    *,
+    timeout_s: float,
+    wait_s: float,
+):
+    start = datetime.now()
+    if not registry:
+        return
+    todo = sorted(registry, key=lambda m: m.version)
+    while "Waiting for DB to be migrated or for a timeout":
+        elapsed = datetime.now() - start
+        if elapsed.total_seconds() > timeout_s:
+            # TODO: add an flag to force the migration cleanup
+            logger.error(_MIGRATION_TIMEOUT_MSG)
+            raise MigrationError(_MIGRATION_TIMEOUT_MSG)
+        migrations = await neo4j_session.execute_read(migrations_tx)
+        in_progress = [m for m in migrations if m.status is MigrationStatus.IN_PROGRESS]
+        if len(in_progress) > 1:
+            raise MigrationError(f"Found several migration in progress: {in_progress}")
+        if in_progress:
+            logger.info(
+                "Found that %s is in progress, waiting for %s seconds...",
+                in_progress[0].label,
+                wait_s,
+            )
+            await asyncio.sleep(wait_s)
+            continue
+        done = [m for m in migrations if m.status is MigrationStatus.DONE]
+        if done:
+            current_version = max((m.version for m in done))
+            todo = [m for m in todo if m.version > current_version]
+        if not todo:
+            break
+        try:
+            await _migration_wrapper(neo4j_session, todo[0])
+            todo = todo[1:]
+            continue
+        except ConstraintError:
+            logger.info(
+                "Migration %s has just started somewhere else, "
+                " waiting for %s seconds...",
+                todo[0].label,
+                wait_s,
+            )
+            await asyncio.sleep(wait_s)
+            continue

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -155,6 +155,13 @@ RETURN m as migration
     return migrations
 
 
+async def delete_all_migrations_tx(tx: neo4j.AsyncTransaction):
+    query = f"""MATCH (m:{MIGRATION_NODE})
+DETACH DELETE m
+    """
+    await tx.run(query)
+
+
 async def migrate_db_schema(
     neo4j_session: neo4j.AsyncSession,
     registry: MigrationRegistry,

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
@@ -1,0 +1,12 @@
+import neo4j
+
+from neo4j_app.constants import MIGRATION_NODE, MIGRATION_VERSION
+
+
+async def create_migration_unique_constraint_tx(tx: neo4j.AsyncTransaction):
+    constraint_query = f"""CREATE CONSTRAINT constraint_migration_unique_version
+IF NOT EXISTS 
+FOR (m:{MIGRATION_NODE})
+REQUIRE (m.{MIGRATION_VERSION}) IS UNIQUE
+"""
+    await tx.run(constraint_query)

--- a/neo4j-app/neo4j_app/core/neo4j/named_entities.py
+++ b/neo4j-app/neo4j_app/core/neo4j/named_entities.py
@@ -8,7 +8,7 @@ from neo4j_app.constants import (
     NE_EXTRACTOR,
     NE_EXTRACTOR_LANG,
     NE_ID,
-    NE_LABEL,
+    NE_NODE,
     NE_MENTION,
     NE_MENTION_NORM,
     NE_MENTION_NORM_TEXT_LENGTH,
@@ -30,7 +30,7 @@ async def import_named_entities_from_csv_tx(
 WITH row, \
 [offset IN split(row.{NE_OFFSETS}, '{NE_OFFSET_SPLITCHAR}') | toInteger(offset)] \
 as rowOffsets  
-MERGE (mention:{NE_LABEL} {{{NE_ID}: row.{NE_ID}}})
+MERGE (mention:{NE_NODE} {{{NE_ID}: row.{NE_ID}}})
 ON CREATE
     SET
         mention.{NE_CATEGORY} = row.{NE_CATEGORY},

--- a/neo4j-app/neo4j_app/core/utils/pydantic.py
+++ b/neo4j-app/neo4j_app/core/utils/pydantic.py
@@ -16,6 +16,7 @@ class BaseICIJModel(BaseModel):
         extra = "forbid"
         allow_population_by_field_name = True
         keep_untouched = (cached_property,)
+        use_enum_values = True
 
     def dict(self, **kwargs):
         kwargs = copy(kwargs)
@@ -34,3 +35,8 @@ class LowerCamelCaseModel(BaseICIJModel):
 class IgnoreExtraModel(BaseICIJModel):
     class Config:
         extra = "ignore"
+
+
+class NoEnumModel(BaseModel):
+    class Config:
+        use_enum_values = False

--- a/neo4j-app/neo4j_app/run/run.py
+++ b/neo4j-app/neo4j_app/run/run.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import uvicorn
 
-import neo4j_app
 from neo4j_app.app.utils import create_app
 from neo4j_app.core.config import AppConfig
 
@@ -51,9 +50,6 @@ def get_arg_parser():
         description="neo4j_app start CLI", formatter_class=Formatter
     )
     arg_parser.add_argument(
-        "-v", "--version", action="store_true", help="Print app version"
-    )
-    arg_parser.add_argument(
         "--config-path",
         type=str,
         help="Path to Java properties holding the app configuration",
@@ -71,8 +67,6 @@ def main():
 
     if hasattr(args, "func"):
         args.func(args)
-    elif "version" in args:
-        print(neo4j_app.__version__)
     else:
         arg_parser.print_help()
         sys.exit(1)

--- a/neo4j-app/neo4j_app/run/run.py
+++ b/neo4j-app/neo4j_app/run/run.py
@@ -1,5 +1,6 @@
 # TODO: rename this into run_http ?
 import argparse
+import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -8,6 +9,10 @@ import uvicorn
 
 from neo4j_app.app.utils import create_app
 from neo4j_app.core.config import AppConfig
+
+DATA_DIR = Path(__file__).parents[3].joinpath(".data")
+NEO4J_TEST_IMPORT_DIR = DATA_DIR.joinpath("neo4j", "import")
+NEO4J_IMPORT_PREFIX = Path(os.sep).joinpath(".neo4j", "import")
 
 
 def debug_app():
@@ -39,7 +44,11 @@ def _start_app(config_path: Optional[str] = None, force_migrations: bool = False
                 f, force_migrations=force_migrations
             )
     else:
-        raise ValueError("Config path is missing")
+        config = AppConfig(
+            neo4j_project="test-datashare-project",
+            neo4j_import_dir=str(NEO4J_TEST_IMPORT_DIR),
+            neo4j_import_prefix=str(NEO4J_IMPORT_PREFIX),
+        )
     app = create_app(config)
     uvicorn_config = config.to_uvicorn()
     uvicorn.run(app, **uvicorn_config.dict())

--- a/neo4j-app/neo4j_app/run/run.py
+++ b/neo4j-app/neo4j_app/run/run.py
@@ -1,9 +1,12 @@
 # TODO: rename this into run_http ?
+import argparse
 import sys
 from pathlib import Path
+from typing import Optional
 
 import uvicorn
 
+import neo4j_app
 from neo4j_app.app.utils import create_app
 from neo4j_app.core.config import AppConfig
 
@@ -18,20 +21,61 @@ def debug_app():
     return app
 
 
-def main():
-    # TODO: add an argument parser if need
-    if len(sys.argv) > 1:
-        config_path = Path(sys.argv[1])
+class Formatter(argparse.ArgumentDefaultsHelpFormatter):
+    def __init__(self, prog):
+        super().__init__(prog, max_help_position=35, width=150)
+
+
+def _start_app_(ns):
+    _start_app(config_path=ns.config_path, force_migrations=ns.force_migrations)
+
+
+def _start_app(config_path: Optional[str] = None, force_migrations: bool = False):
+    if config_path is not None:
+        config_path = Path(config_path)
         if not config_path.exists():
             raise ValueError(f"Provided config path does not exists: {config_path}")
         with config_path.open() as f:
-            config = AppConfig.from_java_properties(f)
+            config = AppConfig.from_java_properties(
+                f, force_migrations=force_migrations
+            )
     else:
         raise ValueError("Config path is missing")
     app = create_app(config)
     uvicorn_config = config.to_uvicorn()
-
     uvicorn.run(app, **uvicorn_config.dict())
+
+
+def get_arg_parser():
+    arg_parser = argparse.ArgumentParser(
+        description="neo4j_app start CLI", formatter_class=Formatter
+    )
+    arg_parser.add_argument(
+        "-v", "--version", action="store_true", help="Print app version"
+    )
+    arg_parser.add_argument(
+        "--config-path",
+        type=str,
+        help="Path to Java properties holding the app configuration",
+    )
+    arg_parser.add_argument(
+        "--force-migrations", action="store_true", help="Force migrations to re-run"
+    )
+    arg_parser.set_defaults(func=_start_app_)
+    return arg_parser
+
+
+def main():
+    arg_parser = get_arg_parser()
+    args = arg_parser.parse_args()
+
+    if hasattr(args, "func"):
+        args.func(args)
+    elif "version" in args:
+        print(neo4j_app.__version__)
+    else:
+        arg_parser.print_help()
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -178,7 +178,7 @@ async def neo4j_test_session_module(
     neo4j_test_session_session: neo4j.AsyncSession,
 ) -> neo4j.AsyncSession:
     session = neo4j_test_session_session
-    await session.execute_write(_wipe_db_tx)
+    await wipe_db(session)
     return session
 
 
@@ -187,7 +187,7 @@ async def neo4j_test_session(
     neo4j_test_session_session: neo4j.AsyncSession,
 ) -> neo4j.AsyncSession:
     session = neo4j_test_session_session
-    await session.execute_write(_wipe_db_tx)
+    await wipe_db(session)
     return session
 
 
@@ -325,12 +325,12 @@ DETACH DELETE ent
     return neo4j_session
 
 
-async def _wipe_db_tx(tx: neo4j.AsyncTransaction):
+async def wipe_db(session: neo4j.AsyncSession):
     # Indices and constraints
     query = "CALL apoc.schema.assert({}, {})"
-    await tx.run(query)
+    await session.run(query)
     # Documents
     query = """MATCH (n)
 DETACH DELETE n
     """
-    await tx.run(query)
+    await session.run(query)

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -17,6 +17,7 @@ from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.app.utils import create_app
 from neo4j_app.core.utils.pydantic import BaseICIJModel
 
+
 # TODO: at a high level it's a waste to have to repeat code for each fixture level,
 #  let's try to find a way to define the scope dynamically:
 #  https://docs.pytest.org/en/6.2.x/fixture.html#dynamic-scope
@@ -24,7 +25,8 @@ from neo4j_app.core.utils.pydantic import BaseICIJModel
 DATA_DIR = Path(__file__).parents[3].joinpath(".data")
 NEO4J_TEST_IMPORT_DIR = DATA_DIR.joinpath("neo4j", "import")
 NEO4J_IMPORT_PREFIX = Path(os.sep).joinpath(".neo4j", "import")
-NEO4J_TEST_PORT = 7687
+ELASTICSEARCH_TEST_PORT = 9201
+NEO4J_TEST_PORT = 7688
 _INDEX_BODY = {
     "mappings": {
         "properties": {
@@ -53,6 +55,7 @@ def test_client_session(
 ) -> TestClient:
     # pylint: disable=unused-argument
     config = AppConfig(
+        elasticsearch_address=f"http://127.0.0.1:{ELASTICSEARCH_TEST_PORT}",
         es_default_page_size=5,
         neo4j_project="test-datashare-project",
         neo4j_import_dir=str(NEO4J_TEST_IMPORT_DIR),
@@ -119,7 +122,7 @@ def _make_test_client() -> ESClient:
     test_index = "test-datashare-project"
     es = ESClient(
         project_index=test_index,
-        hosts=[{"host": "localhost", "port": 9200}],
+        hosts=[{"host": "localhost", "port": ELASTICSEARCH_TEST_PORT}],
         pagination=3,
     )
     return es

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -170,6 +170,7 @@ async def neo4j_test_session_session(
 ) -> AsyncGenerator[neo4j.AsyncSession, None]:
     driver = neo4j_test_driver_session
     async with driver.session(database=neo4j.DEFAULT_DATABASE) as sess:
+        await wipe_db(sess)
         yield sess
 
 

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
@@ -23,7 +23,7 @@ async def _migration_index_and_constraint(
     neo4j_test_session: neo4j.AsyncSession,
 ) -> neo4j.AsyncSession:
     await migrate_db_schema(
-        neo4j_test_session, _BASE_REGISTRY, timeout_s=30, wait_s=0.1
+        neo4j_test_session, _BASE_REGISTRY, timeout_s=30, throttle_s=0.1
     )
     return neo4j_test_session
 
@@ -78,7 +78,7 @@ async def test_migrate_db_schema(
     neo4j_session = _migration_index_and_constraint
 
     # When
-    await migrate_db_schema(neo4j_session, registry, timeout_s=10, wait_s=0.1)
+    await migrate_db_schema(neo4j_session, registry, timeout_s=10, throttle_s=0.1)
 
     # Then
     index_res = await neo4j_session.run("SHOW INDEXES")
@@ -115,7 +115,7 @@ async def test_migrate_db_schema_should_raise_after_timeout(
     # When
     expected_msg = "Migration timeout expired"
     with pytest.raises(MigrationError, match=expected_msg):
-        await migrate_db_schema(neo4j_session, registry, timeout_s=0, wait_s=0.1)
+        await migrate_db_schema(neo4j_session, registry, timeout_s=0, throttle_s=0.1)
 
 
 @pytest.mark.asyncio
@@ -151,7 +151,7 @@ async def test_migrate_db_schema_should_wait_when_other_migration_in_progress(
             neo4j_session_0,
             [_MIGRATION_0, _MIGRATION_1],
             timeout_s=timeout_s,
-            wait_s=wait_s,
+            throttle_s=wait_s,
         )
     # Check that we've slept at least once otherwise timeout must be increased...
     assert any(
@@ -193,7 +193,7 @@ async def test_migrate_db_schema_should_wait_when_other_migration_just_started(
             neo4j_session_0,
             [_MIGRATION_0],
             timeout_s=timeout_s,
-            wait_s=wait_s,
+            throttle_s=wait_s,
         )
     # Check that we've slept at least once otherwise timeout must be increased...
     assert any(

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
@@ -1,0 +1,203 @@
+import logging
+from datetime import datetime
+from typing import List, Set
+
+import neo4j
+import pytest
+import pytest_asyncio
+
+import neo4j_app
+from neo4j_app.core.neo4j import FIRST_MIGRATION, Migration, migrate_db_schema
+from neo4j_app.core.neo4j.migrations import migrate
+from neo4j_app.core.neo4j.migrations.migrate import (
+    MigrationError,
+    MigrationStatus,
+    Neo4jMigration,
+)
+
+_BASE_REGISTRY = [FIRST_MIGRATION]
+
+
+@pytest_asyncio.fixture(scope="function")
+async def _migration_index_and_constraint(
+    neo4j_test_session: neo4j.AsyncSession,
+) -> neo4j.AsyncSession:
+    await migrate_db_schema(
+        neo4j_test_session, _BASE_REGISTRY, timeout_s=30, wait_s=0.1
+    )
+    return neo4j_test_session
+
+
+async def _create_indexes_tx(tx: neo4j.AsyncTransaction):
+    index_query_0 = "CREATE INDEX index0 IF NOT EXISTS FOR (n:Node) ON (n.attribute0)"
+    await tx.run(index_query_0)
+    index_query_1 = "CREATE INDEX index1 IF NOT EXISTS FOR (n:Node) ON (n.attribute1)"
+    await tx.run(index_query_1)
+
+
+async def _drop_constraint_tx(tx: neo4j.AsyncTransaction):
+    drop_index_query = "DROP INDEX index0 IF EXISTS"
+    await tx.run(drop_index_query)
+
+
+# noinspection PyTypeChecker
+_MIGRATION_0 = Migration(
+    version="0.2.0",
+    label="create index and constraint",
+    migration_fn=_create_indexes_tx,
+)
+# noinspection PyTypeChecker
+_MIGRATION_1 = Migration(
+    version="0.3.0",
+    label="drop constraint",
+    migration_fn=_drop_constraint_tx,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "registry,expected_indexes,not_expected_indexes",
+    [
+        # No migration
+        ([], set(), set()),
+        # Single
+        ([_MIGRATION_0], {"index0", "index1"}, set()),
+        # Multiple ordered
+        ([_MIGRATION_0, _MIGRATION_1], {"index1"}, {"index0"}),
+        # Multiple unordered
+        ([_MIGRATION_1, _MIGRATION_0], {"index1"}, {"index0"}),
+    ],
+)
+async def test_migrate_db_schema(
+    _migration_index_and_constraint: neo4j.AsyncSession,  # pylint: disable=invalid-name
+    registry: List[Migration],
+    expected_indexes: Set[str],
+    not_expected_indexes: Set[str],
+):
+    # Given
+    neo4j_session = _migration_index_and_constraint
+
+    # When
+    await migrate_db_schema(neo4j_session, registry, timeout_s=10, wait_s=0.1)
+
+    # Then
+    index_res = await neo4j_session.run("SHOW INDEXES")
+    existing_indexes = set()
+    async for rec in index_res:
+        existing_indexes.add(rec["name"])
+    missing_indexes = expected_indexes - existing_indexes
+    assert not missing_indexes
+    assert not not_expected_indexes.intersection(existing_indexes)
+
+    if registry:
+        db_migrations_res = await neo4j_session.run(
+            "MATCH (m:Migration) RETURN m as migration"
+        )
+        db_migrations = [
+            Neo4jMigration.from_neo4j(rec, key="migration")
+            async for rec in db_migrations_res
+        ]
+        assert len(db_migrations) == len(registry) + 1
+        assert all(m.status is MigrationStatus.DONE for m in db_migrations)
+        max_version = max(m.version for m in registry)
+        db_version = max(m.version for m in db_migrations)
+        assert db_version == max_version
+
+
+@pytest.mark.asyncio
+async def test_migrate_db_schema_should_raise_after_timeout(
+    neo4j_test_session_session: neo4j.AsyncSession,
+):
+    # Given
+    neo4j_session = neo4j_test_session_session
+    registry = [_MIGRATION_0]
+
+    # When
+    expected_msg = "Migration timeout expired"
+    with pytest.raises(MigrationError, match=expected_msg):
+        await migrate_db_schema(neo4j_session, registry, timeout_s=0, wait_s=0.1)
+
+
+@pytest.mark.asyncio
+async def test_migrate_db_schema_should_wait_when_other_migration_in_progress(
+    caplog,
+    monkeypatch,
+    _migration_index_and_constraint: neo4j.AsyncSession,  # pylint: disable=invalid-name
+):
+    # Given
+    neo4j_session_0 = _migration_index_and_constraint
+    caplog.set_level(logging.INFO, logger=neo4j_app.__name__)
+
+    async def mocked_get_migrations(
+        sess: neo4j.AsyncSession,  # pylint: disable=unused-argument
+    ) -> List[Neo4jMigration]:
+        return [
+            Neo4jMigration(
+                version="0.1.0",
+                label="migration in progress",
+                status=MigrationStatus.IN_PROGRESS,
+                started=datetime.now(),
+            )
+        ]
+
+    monkeypatch.setattr(migrate, "migrations_tx", mocked_get_migrations)
+
+    # When/Then
+    expected_msg = "Migration timeout expired "
+    with pytest.raises(MigrationError, match=expected_msg):
+        timeout_s = 0.5
+        wait_s = 0.1
+        await migrate_db_schema(
+            neo4j_session_0,
+            [_MIGRATION_0, _MIGRATION_1],
+            timeout_s=timeout_s,
+            wait_s=wait_s,
+        )
+    # Check that we've slept at least once otherwise timeout must be increased...
+    assert any(
+        rec.name == "neo4j_app.core.neo4j.migrations.migrate"
+        and f"waiting for {wait_s}" in rec.message
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_migrate_db_schema_should_wait_when_other_migration_just_started(
+    monkeypatch, caplog, _migration_index_and_constraint  # pylint: disable=invalid-name
+):
+    # Given
+    neo4j_session_0 = _migration_index_and_constraint
+    caplog.set_level(logging.INFO, logger=neo4j_app.__name__)
+
+    async def mocked_get_migrations(
+        sess: neo4j.AsyncSession,  # pylint: disable=unused-argument
+    ) -> List[Neo4jMigration]:
+        return []
+
+    # No migration in progress
+    monkeypatch.setattr(migrate, "migrations_tx", mocked_get_migrations)
+
+    # However we simulate _MIGRATION_0 being running just before our migrate_db_schema
+    # by inserting it in progress
+    await neo4j_session_0.run(
+        "CREATE (m:Migration { version: $version })",
+        version=str(_MIGRATION_0.version),
+    )
+
+    # When/Then
+    expected_msg = "Migration timeout expired "
+    with pytest.raises(MigrationError, match=expected_msg):
+        timeout_s = 0.5
+        wait_s = 0.1
+        await migrate_db_schema(
+            neo4j_session_0,
+            [_MIGRATION_0],
+            timeout_s=timeout_s,
+            wait_s=wait_s,
+        )
+    # Check that we've slept at least once otherwise timeout must be increased...
+    assert any(
+        rec.name == "neo4j_app.core.neo4j.migrations.migrate"
+        and "just started" in rec.message
+        for rec in caplog.records
+    )

--- a/neo4j-app/neo4j_app/tests/run/test_run.py
+++ b/neo4j-app/neo4j_app/tests/run/test_run.py
@@ -13,8 +13,15 @@ def test_should_read_java_properties(tmpdir: Path):
 
     # When
     with pytest.raises(subprocess.CalledProcessError) as exception_info:
+        cmd = [
+            "python",
+            str(run_path),
+            "--config-path",
+            str(missing_config_file_path),
+            "--force-migrations",
+        ]
         subprocess.run(
-            ["python", str(run_path), str(missing_config_file_path)],
+            cmd,
             check=True,
             capture_output=True,
             encoding="utf-8",

--- a/src/main/java/org/icij/datashare/Objects.java
+++ b/src/main/java/org/icij/datashare/Objects.java
@@ -29,4 +29,13 @@ public class Objects {
             this.query = query;
         }
     }
+
+    static class StartNeo4jAppRequest {
+        public boolean forceMigration;
+
+        @JsonCreator
+        StartNeo4jAppRequest(@JsonProperty("forceMigration") boolean forceMigration) {
+            this.forceMigration = forceMigration;
+        }
+    }
 }

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -134,7 +134,7 @@ public class Neo4jResourceTest {
         @Test
         public void test_get_ping() throws IOException, InterruptedException {
             // When
-            neo4jAppResource.startServerProcess();
+            neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(routes -> routes.get("/ping", (context) -> "pong"));
             Response res =
                 get("/api/neo4j/ping").withPreemptiveAuthentication("foo", "null").response();
@@ -185,7 +185,7 @@ public class Neo4jResourceTest {
         @Test
         public void test_get_ping_should_return_200() throws IOException, InterruptedException {
             // When
-            neo4jAppResource.startServerProcess();
+            neo4jAppResource.startServerProcess(false);
             Response response =
                 get("/api/neo4j/ping").withPreemptiveAuthentication("foo", "null").response();
             // Then
@@ -214,7 +214,7 @@ public class Neo4jResourceTest {
         @Test
         public void test_get_status_when_running() throws IOException, InterruptedException {
             // When
-            neo4jAppResource.startServerProcess();
+            neo4jAppResource.startServerProcess(false);
             Response response =
                 get("/api/neo4j/status").withPreemptiveAuthentication("foo", "null").response();
             // Then
@@ -244,7 +244,7 @@ public class Neo4jResourceTest {
         public void test_post_start_should_return_200_when_already_started()
             throws IOException, InterruptedException {
             // When
-            neo4jAppResource.startServerProcess();
+            neo4jAppResource.startServerProcess(false);
             Response response =
                 post("/api/neo4j/start").withPreemptiveAuthentication("foo", "null").response();
             // Then
@@ -274,7 +274,7 @@ public class Neo4jResourceTest {
         public void test_post_stop_should_return_200_when_already_started()
             throws IOException, InterruptedException {
             // When
-            neo4jAppResource.startServerProcess();
+            neo4jAppResource.startServerProcess(false);
             Response response =
                 post("/api/neo4j/stop").withPreemptiveAuthentication("foo", "null").response();
             // Then
@@ -357,7 +357,7 @@ public class Neo4jResourceTest {
         public void test_post_documents_import_should_return_200()
             throws IOException, InterruptedException {
             // Given
-            neo4jAppResource.startServerProcess();
+            neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
                 routes -> routes.post(
                     "/documents",
@@ -405,7 +405,7 @@ public class Neo4jResourceTest {
         public void test_post_named_entities_import_should_return_200()
             throws IOException, InterruptedException {
             // Given
-            neo4jAppResource.startServerProcess();
+            neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
                 routes -> routes.post(
                     "/named-entities",


### PR DESCRIPTION
# TODO:
- [x] merge https://github.com/ICIJ/datashare-extension-neo4j/pull/17 first

# PR description

This PR adds the ability to run migrations at the extension startup (this will be needed to add some indexes to `neo4j`).

## Migration engine

Implemented a migration `neo4j.core.neo4j.migrate_db_schema` functions which has the following properties
- it takes a list of migration `Migration` objects which all have a `version`
- if fetches already run migrations from the `neo4j` DB
- based on the latest migration run on the DB it will try to run later migrations
- concurrent migrations are handle the following way:
	- the `neo4j` DB has a `Migration` collection with uniqueness constraint on the `version`
	- when a migration is selected as a candidate to be run against the DB the current thread will try to `CREATE` in with the `MigrationStatus.IN_PROGRESS` status
	- because of the uniqueness constraint if any other source has inserted that migration earlier, then the current thread will wait before retrying or running a newer migration
	- when the migration is successfully run it is markes as `MigrationStatus.DONE` and the function will try later migrations

This concurrency handling scheme implies that DB can be in a locked state in the case a migration fails after acquiring the migration lock. To mitigate this downside the ability to startup the application wiping the `Migration` collection was added. Doing so will delete any dangling/locking migration and all migration will hence be re-run. If the DB is locked again, it will hence be very likely that the lock was not happenning randomly and that some migration is badly written (which should not happen since they will all be unit tested).

This downside was considered acceptable as some migration can be very costly (such index creation on an heavily populated DB).


## Migration functions
**For now migrations are expected to be idempotent**. Later it will be possible to leverage the fact that migrations are versioned using semver, in order not to run migrations which can't be run any longer due to breaking changes.

When wiping the migration index in case of lock, we'll prevent from wiping migrations which are in lower majors, this way we'll never try to re-run them again.


# Changes

## `datashare-extension-neo4j/neo4j-app`
### Added
- Run schema migrations at the application startup using a `FastAPI` `startup` event handler

## `datashare-extension-neo4j/neo4j`
### Changed
- Changed `elasticsearch` and `neo4j` port to custom ports to avoid interactions with services on default ports


# Left for later:
- run migrations according to the semver
