### PR TITLE
chore: improve Python process lifecycle management

### DIFF
--- a/src/main/java/org/icij/datashare/ProcessUtils.java
+++ b/src/main/java/org/icij/datashare/ProcessUtils.java
@@ -1,0 +1,78 @@
+package org.icij.datashare;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+public class ProcessUtils {
+
+    public static void dumpPid(File pidFile, Long pid) throws IOException {
+        boolean ignored = pidFile.getParentFile().mkdirs();
+        try (FileOutputStream fos = new FileOutputStream(pidFile)) {
+            fos.write(pid.toString().getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    public static Long isProcessRunning(Path pidPath, int timeout, TimeUnit timeunit)
+        throws IOException, InterruptedException {
+        try (Stream<String> lines = Files.lines(pidPath)) {
+            Long pid = Long.parseLong(
+                lines.findFirst()
+                    .orElseThrow(() -> new RuntimeException("PID file is empty"))
+                    .strip()
+            );
+            if (isProcessRunning(pid, timeout, timeunit)) {
+                return pid;
+            }
+        }
+        return null;
+    }
+
+    public static boolean isProcessRunning(Long pid, int timeout, TimeUnit timeunit)
+        throws IOException, InterruptedException {
+        boolean isWindows = System.getProperty("os.name").toLowerCase().startsWith("windows");
+        if (isWindows) {
+            throw new RuntimeException("Datashare neo4j extension is not supported on Windows");
+        }
+        ProcessBuilder builder = new ProcessBuilder();
+        builder.command("ps", "-p", pid.toString());
+        Process process = builder.start();
+        if (process.waitFor(timeout, timeunit)) {
+            return process.exitValue() == 0;
+        } else {
+            throw new RuntimeException(
+                "Failed to process "
+                    + pid
+                    + "status using the ps command in less than "
+                    + timeout
+                    + timeunit.toString()
+            );
+        }
+    }
+
+    public static void killProcessById(Long pid) {
+        killProcessById(pid, false);
+    }
+
+    public static void killProcessById(Long pid, boolean force) {
+        Stream<ProcessHandle> liveProcesses = ProcessHandle.allProcesses();
+        liveProcesses
+            .filter(handle -> handle.isAlive() && pid.equals(handle.pid()))
+            .findFirst()
+            .ifPresent(parent -> parent
+                .descendants()
+                .forEach(child -> {
+                    if (force) {
+                        child.destroyForcibly();
+                    } else {
+                        child.destroy();
+                    }
+                })
+            );
+    }
+}

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -58,7 +58,7 @@ public class Neo4jResourceTest {
     public static class BindNeo4jResource extends ProdWebServerRuleExtension
         implements BeforeAllCallback, AfterEachCallback {
         @Override
-        public void beforeAll(ExtensionContext extensionContext) {
+        public void beforeAll(ExtensionContext extensionContext) throws IOException {
             neo4jAppResource = new Neo4jResource(propertyProvider);
             this.configure(
                 routes -> routes
@@ -69,8 +69,9 @@ public class Neo4jResourceTest {
         }
 
         @Override
-        public void afterEach(ExtensionContext extensionContext) {
-            neo4jAppResource.close();
+        public void afterEach(ExtensionContext extensionContext)
+            throws IOException, InterruptedException {
+            Neo4jResource.stopServerProcess();
         }
     }
 
@@ -94,8 +95,9 @@ public class Neo4jResourceTest {
         }
 
         @Override
-        public void afterEach(ExtensionContext extensionContext) {
-            neo4jAppResource.close();
+        public void afterEach(ExtensionContext extensionContext)
+            throws IOException, InterruptedException {
+            Neo4jResource.stopServerProcess();
         }
     }
 
@@ -106,8 +108,9 @@ public class Neo4jResourceTest {
         }
 
         @Override
-        public void afterEach(ExtensionContext extensionContext) {
-            neo4jAppResource.close();
+        public void afterEach(ExtensionContext extensionContext)
+            throws IOException, InterruptedException {
+            Neo4jResource.stopServerProcess();
         }
     }
 
@@ -124,7 +127,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_not_be_running_by_default() {
+        public void test_not_be_running_by_default() throws IOException, InterruptedException {
             // When
             Neo4jResource.Neo4jAppStatus status = neo4jAppResource.getStopNeo4jApp();
             // Then

--- a/src/test/resources/shell_mock
+++ b/src/test/resources/shell_mock
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-ls .
+while true; do
+    sleep 10000
+done


### PR DESCRIPTION
# PR description

This PR improves the management of the Python process lifecycle. In the current implementation, the Java application owns a Python process and try to kill the Python process when the extension closes. However if the extension crashes, it might not succeed to kill the process leaving a phantom Python process.

Additionnally some processing might be in progress on the Python side while closing the app.

This PR aims at decoupling the life of both processes.

# Changes

## `datashare-extension-neo4j/src`
### Changed
- When calling `Neo4jResource.startServerProcess`, the extension now dumps the Python process PID in `/tmp`. When checking if the app is running, the extension now looks for the PID file in `/tmp`, if present, it will read the process ID and ask the OS for the process state. If the process is not alive the PID file is cleaned.

### Added
- Added several utils to get information about processes running on the OS in `ProcessUtils`