### PR TITLE
chore: optimize incremental imports

### DIFF
--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -38,6 +38,8 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     elasticsearch_version: str = Field(default_factory=_es_version, const=True)
     es_doc_type_field: str = Field(alias="docTypeField", default="type")
     es_default_page_size: int = 1000
+    es_max_concurrency: int = 5
+    es_timeout: int = "1m"
     es_keep_alive: str = "1m"
     neo4j_app_host: str = "127.0.0.1"
     neo4j_app_log_level: str = "INFO"
@@ -146,6 +148,7 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
             hosts=[self.es_host],
             port=self.es_port,
             pagination=self.es_default_page_size,
+            max_concurrency=self.es_max_concurrency,
         )
         return client
 

--- a/neo4j-app/neo4j_app/core/elasticsearch/client.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/client.py
@@ -25,6 +25,7 @@ from neo4j_app.core.elasticsearch.utils import (
     match_all,
 )
 from neo4j_app.core.neo4j import write_neo4j_csv
+from neo4j_app.core.utils.logging import log_elapsed_time_cm
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,10 @@ class ESClientABC(metaclass=abc.ABCMeta):
             size = self.pagination_size
         if not size:
             raise ValueError("size is expected to be > 0")
-        res = await self.search(size=size, sort=sort, **kwargs)
+        with log_elapsed_time_cm(
+            logger, logging.DEBUG, "Searched in ES in {elapsed_time}"
+        ):
+            res = await self.search(size=size, sort=sort, **kwargs)
         kwargs = deepcopy(kwargs)
         yield res
         page_hits = res[HITS][HITS]
@@ -91,7 +95,10 @@ class ESClientABC(metaclass=abc.ABCMeta):
                 kwargs["body"][SEARCH_AFTER] = search_after
             else:
                 kwargs[SEARCH_AFTER] = search_after
-            res = await self.search(size=size, sort=sort, **kwargs)
+            with log_elapsed_time_cm(
+                logger, logging.DEBUG, "Searched in ES in {elapsed_time}"
+            ):
+                res = await self.search(size=size, sort=sort, **kwargs)
             yield res
             page_hits = res[HITS][HITS]
 

--- a/neo4j-app/neo4j_app/core/imports.py
+++ b/neo4j-app/neo4j_app/core/imports.py
@@ -132,6 +132,7 @@ async def _es_to_neo4j_import(
     concurrency: Optional[int] = None,
     imported_entity_label: str,
 ) -> IncrementalImportResponse:
+    logger.debug("Importing with ES concurrency of %s", concurrency)
     with make_neo4j_import_file(
         neo4j_import_dir=neo4j_import_dir, neo4j_import_prefix=neo4j_import_prefix
     ) as (f, neo4j_import_path):
@@ -161,3 +162,6 @@ async def _es_to_neo4j_import(
     n_inserted = summary.counters.nodes_created
     response = IncrementalImportResponse(n_to_insert=n_to_insert, n_inserted=n_inserted)
     return response
+
+
+œ

--- a/neo4j-app/neo4j_app/core/imports.py
+++ b/neo4j-app/neo4j_app/core/imports.py
@@ -154,7 +154,8 @@ async def _es_to_neo4j_import(
         with log_elapsed_time_cm(
             logger,
             logging.DEBUG,
-            f"Imported {imported_entity_label} from csv to neo4j in {{elapsed_time}}",
+            f"Imported {imported_entity_label} from csv to neo4j in"
+            f" {{elapsed_time}}",
         ):
             summary: neo4j.ResultSummary = await neo4j_session.execute_write(
                 import_tx, neo4j_import_path=neo4j_import_path
@@ -162,6 +163,3 @@ async def _es_to_neo4j_import(
     n_inserted = summary.counters.nodes_created
     response = IncrementalImportResponse(n_to_insert=n_to_insert, n_inserted=n_inserted)
     return response
-
-
-œ

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -6,14 +6,22 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional, TextIO, Tuple
 from .migrations import Migration
 from .migrations.migrate import migrate_db_schema, MigrationError
-from .migrations.migrations import create_migration_unique_constraint_tx
+from .migrations.migrations import (
+    create_document_and_ne_id_unique_constraint_tx,
+    create_migration_unique_constraint_tx,
+)
 
 FIRST_MIGRATION = Migration(
     version="0.1.0",
     label="Create migration index and constraints",
     migration_fn=create_migration_unique_constraint_tx,
 )
-MIGRATIONS = [FIRST_MIGRATION]
+V_O_2_0 = Migration(
+    version="0.2.0",
+    label="Add uniqueness constraint for documents and named entities",
+    migration_fn=create_document_and_ne_id_unique_constraint_tx,
+)
+MIGRATIONS = [FIRST_MIGRATION, V_O_2_0]
 
 
 def get_neo4j_csv_writer(f: TextIO, header: List[str]) -> csv.DictWriter:

--- a/neo4j-app/neo4j_app/core/neo4j/documents.py
+++ b/neo4j-app/neo4j_app/core/neo4j/documents.py
@@ -19,11 +19,7 @@ async def import_documents_from_csv_tx(
     tx: neo4j.AsyncTransaction, neo4j_import_path: Path
 ) -> neo4j.ResultSummary:
     # TODO: use apoc.periodic.iterate(.., ..., {batchSize:10000, parallel:true,
-    #  iterateList:true}) to || and speed import...
-    # TODO: if this is too long it might be worth skipping the ON MATCH part,
-    #  if we do so properties updates will be disabled and in this case we'll want to
-    #  have route to clean the DB and start fresh
-    # TODO: add an index on document id
+    #  iterateList:true}) to || and save memory import...
     query = f"""LOAD CSV WITH HEADERS FROM 'file:///{neo4j_import_path}' AS row
 MERGE (doc:{DOC_NODE} {{{DOC_ID}: row.{DOC_ID}}})
 ON CREATE

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
@@ -1,6 +1,13 @@
 import neo4j
 
-from neo4j_app.constants import MIGRATION_NODE, MIGRATION_VERSION
+from neo4j_app.constants import (
+    DOC_ID,
+    DOC_NODE,
+    MIGRATION_NODE,
+    MIGRATION_VERSION,
+    NE_ID,
+    NE_NODE,
+)
 
 
 async def create_migration_unique_constraint_tx(tx: neo4j.AsyncTransaction):
@@ -10,3 +17,18 @@ FOR (m:{MIGRATION_NODE})
 REQUIRE (m.{MIGRATION_VERSION}) IS UNIQUE
 """
     await tx.run(constraint_query)
+
+
+async def create_document_and_ne_id_unique_constraint_tx(tx: neo4j.AsyncTransaction):
+    doc_query = f"""CREATE CONSTRAINT constraint_document_unique_id
+IF NOT EXISTS 
+FOR (doc:{DOC_NODE})
+REQUIRE (doc.{DOC_ID}) IS UNIQUE
+"""
+    await tx.run(doc_query)
+    ne_query = f"""CREATE CONSTRAINT constraint_named_entity_unique_id
+IF NOT EXISTS 
+FOR (ent:{NE_NODE})
+REQUIRE (ent.{NE_ID}) IS UNIQUE
+"""
+    await tx.run(ne_query)

--- a/neo4j-app/neo4j_app/core/neo4j/named_entities.py
+++ b/neo4j-app/neo4j_app/core/neo4j/named_entities.py
@@ -21,11 +21,7 @@ async def import_named_entities_from_csv_tx(
     tx: neo4j.AsyncTransaction, neo4j_import_path: Path
 ) -> neo4j.ResultSummary:
     # TODO: use apoc.periodic.iterate(.., ..., {batchSize:10000, parallel:true,
-    #  iterateList:true}) to || and speed import...
-    # TODO: if this is too long it might be worth skipping the ON MATCH part,
-    #  if we do so properties updates will be disabled and in this case we'll want to
-    #  have route to clean the DB and start fresh
-    # TODO: add an index on document id
+    #  iterateList:true}) to || and save memory import...
     query = f"""LOAD CSV WITH HEADERS FROM 'file:///{neo4j_import_path}' AS row
 WITH row, \
 [offset IN split(row.{NE_OFFSETS}, '{NE_OFFSET_SPLITCHAR}') | toInteger(offset)] \

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -1,0 +1,27 @@
+import neo4j
+import pytest
+
+from neo4j_app.core.neo4j import create_document_and_ne_id_unique_constraint_tx
+
+
+@pytest.mark.asyncio
+async def test_create_document_and_ne_id_unique_constraint_tx(
+    neo4j_test_session: neo4j.AsyncSession,
+):
+    # Given
+    constraints_res = await neo4j_test_session.run("SHOW CONSTRAINTS")
+    existing_constraints = set()
+    async for rec in constraints_res:
+        existing_constraints.add(rec["name"])
+
+    # When
+    await neo4j_test_session.execute_write(
+        create_document_and_ne_id_unique_constraint_tx
+    )
+
+    # Then
+    constraints_res = await neo4j_test_session.run("SHOW CONSTRAINTS")
+    async for rec in constraints_res:
+        existing_constraints.add(rec["name"])
+    assert "constraint_document_unique_id" in existing_constraints
+    assert "constraint_named_entity_unique_id" in existing_constraints

--- a/neo4j-app/pyproject.toml
+++ b/neo4j-app/pyproject.toml
@@ -28,7 +28,6 @@ pytest = "^7.2.1"
 pytest-asyncio = "^0.20.3"
 tomli = { version = "^2.0.1", markers = 'python_version < "3.11"' }
 
-
 [tool.poetry.group.opensearch.dependencies]
 opensearch-py = "^2.2.0"
 

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -103,7 +103,7 @@ public class Neo4jResource implements AutoCloseable {
                 Thread.sleep(500);
             }
         }
-        throw new RuntimeException("Couldn't read Python 30s after starting it !");
+        throw new RuntimeException("Couldn't start Python 30s after starting it !");
     }
 
     @Post("/start")


### PR DESCRIPTION
# PR description

Leverage the work done in #18 in order to add uniqueness constraints and reduce incremental import by `x100`


# Changes

## `datashare-extension-neo4j/neo4j-app`

### Added
- Added the `create_document_and_ne_id_unique_constraint_tx` migration to speed up document and named entities import time
- Added a `AppConfig.es_max_concurrency` in order to be able to configure the ES concurrency and speedup imports