### PR TITLE
chore: in-memory incremental import

### DIFF
--- a/neo4j-app/neo4j_app/app/documents.py
+++ b/neo4j-app/neo4j_app/app/documents.py
@@ -1,9 +1,12 @@
 import logging
-from pathlib import Path
 
+import neo4j
 from fastapi import APIRouter, Depends, Request
 
-from neo4j_app.app.dependencies import es_client_dep, neo4j_session_dep
+from neo4j_app.app.dependencies import (
+    es_client_dep,
+    neo4j_driver_dep,
+)
 from neo4j_app.core import AppConfig
 from neo4j_app.core.elasticsearch import ESClientABC
 from neo4j_app.core.imports import import_documents
@@ -57,7 +60,7 @@ app to the Python one through configuration.
 
 
 def documents_router() -> APIRouter:
-    router = APIRouter(dependencies=[Depends(neo4j_session_dep)], tags=[DOCUMENT_TAG])
+    router = APIRouter(tags=[DOCUMENT_TAG])
 
     @router.post(
         "/documents",
@@ -68,24 +71,24 @@ def documents_router() -> APIRouter:
     async def _import_documents(
         payload: IncrementalImportRequest,
         request: Request,
+        neo4j_driver: neo4j.AsyncDriver = Depends(neo4j_driver_dep),
         es_client: ESClientABC = Depends(es_client_dep),
     ) -> IncrementalImportResponse:
-        neo4j_sess = request.state.neo4j_session
         config: AppConfig = request.app.state.config
-
         with log_elapsed_time_cm(
             logger, logging.INFO, "Imported documents in {elapsed_time} !"
         ):
             res = await import_documents(
-                query=payload.query,
-                neo4j_session=neo4j_sess,
                 es_client=es_client,
-                neo4j_import_dir=Path(config.neo4j_import_dir),
-                neo4j_import_prefix=config.neo4j_import_prefix,
-                keep_alive=config.es_keep_alive,
-                doc_type_field=config.es_doc_type_field,
-                # TODO: take this one from the payload
-                concurrency=es_client.max_concurrency,
+                es_query=payload.query,
+                es_concurrency=es_client.max_concurrency,
+                es_keep_alive=config.es_keep_alive,
+                es_doc_type_field=config.es_doc_type_field,
+                neo4j_driver=neo4j_driver,
+                neo4j_concurrency=config.neo4j_concurrency,
+                neo4j_import_batch_size=config.neo4j_import_batch_size,
+                neo4j_transaction_batch_size=config.neo4j_transaction_batch_size,
+                max_records_in_memory=config.max_records_in_memory,
             )
         return res
 

--- a/neo4j-app/neo4j_app/app/documents.py
+++ b/neo4j-app/neo4j_app/app/documents.py
@@ -88,7 +88,7 @@ def documents_router() -> APIRouter:
                 neo4j_concurrency=config.neo4j_concurrency,
                 neo4j_import_batch_size=config.neo4j_import_batch_size,
                 neo4j_transaction_batch_size=config.neo4j_transaction_batch_size,
-                max_records_in_memory=config.max_records_in_memory,
+                max_records_in_memory=config.neo4j_app_max_records_in_memory,
             )
         return res
 

--- a/neo4j-app/neo4j_app/app/named_entities.py
+++ b/neo4j-app/neo4j_app/app/named_entities.py
@@ -96,7 +96,7 @@ def named_entities_router() -> APIRouter:
                 neo4j_concurrency=config.neo4j_concurrency,
                 neo4j_import_batch_size=config.neo4j_import_batch_size,
                 neo4j_transaction_batch_size=config.neo4j_transaction_batch_size,
-                max_records_in_memory=config.max_records_in_memory,
+                max_records_in_memory=config.neo4j_app_max_records_in_memory,
             )
         return res
 

--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -24,8 +24,6 @@ MIGRATION_STARTED = "started"
 MIGRATION_STATUS = "status"
 MIGRATION_VERSION = "version"
 
-NE_OFFSET_SPLITCHAR = ":"
-
 # TODO: replicate other named entities attributes
 NE_ID = "id"
 NE_CATEGORY = "category"

--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -41,9 +41,9 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     es_max_concurrency: int = 5
     es_timeout: int = "1m"
     es_keep_alive: str = "1m"
-    max_records_in_memory: int = int(1e6)
     neo4j_app_host: str = "127.0.0.1"
     neo4j_app_log_level: str = "INFO"
+    neo4j_app_max_records_in_memory: int = int(1e6)
     neo4j_app_migration_timeout_s: float = 60 * 5
     neo4j_app_migration_throttle_s: float = 1
     neo4j_app_name: str = "neo4j app"
@@ -51,12 +51,12 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     neo4j_app_syslog_facility: Optional[str] = None
     neo4j_app_uses_opensearch: bool = False
     neo4j_concurrency: int = 2
-    neo4j_import_batch_size: int = int(5e5)
-    neo4j_transaction_batch_size = 50000
     neo4j_connection_timeout: float = 5.0
     neo4j_host: str = "127.0.0.1"
+    neo4j_import_batch_size: int = int(5e5)
     neo4j_port: int = 7687
     neo4j_project: str
+    neo4j_transaction_batch_size = 50000
     force_migrations: bool = False
 
     # Ugly but hard to do differently if we want to avoid to retrieve the config on a
@@ -67,9 +67,11 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     def neo4j_import_batch_size_must_be_less_than_max_records_in_memory(  # pylint: disable=no-self-argument
         cls, v, values
     ):
-        max_records = values["max_records_in_memory"]
+        max_records = values["neo4j_app_max_records_in_memory"]
         if v > max_records:
-            raise ValueError("neo4j_import_batch_size must be <= max_records_in_memory")
+            raise ValueError(
+                "neo4j_import_batch_size must be <= neo4j_app_max_records_in_memory"
+            )
         return v
 
     @classmethod

--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -174,7 +174,6 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
             neo4j_app.__name__,
             uvicorn.__name__,
             elasticsearch.__name__,
-            neo4j.__name__,
         ]
         try:
             import opensearchpy

--- a/neo4j-app/neo4j_app/core/elasticsearch/to_neo4j.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/to_neo4j.py
@@ -6,8 +6,6 @@ from neo4j_app.constants import (
     NE_COLUMNS,
     NE_DOC_ID,
     NE_ID,
-    NE_OFFSETS,
-    NE_OFFSET_SPLITCHAR,
 )
 from neo4j_app.core.elasticsearch.utils import JOIN, PARENT, SOURCE
 
@@ -22,12 +20,9 @@ def es_to_neo4j_doc(document_hit: Dict) -> Dict[str, str]:
 def es_to_neo4j_named_entity(ne_hit: Dict) -> Dict[str, str]:
     ent = {NE_ID: ne_hit["_id"]}
     hit_source = ne_hit[SOURCE]
-    excluded = {NE_OFFSETS, JOIN}
+    excluded = {JOIN}
     ent.update(
         {k: hit_source[k] for k in hit_source if k in NE_COLUMNS if k not in excluded}
-    )
-    ent[NE_OFFSETS] = NE_OFFSET_SPLITCHAR.join(
-        str(off) for off in hit_source[NE_OFFSETS]
     )
     ent[NE_DOC_ID] = hit_source[JOIN][PARENT]
     return ent

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -4,10 +4,13 @@ import tempfile
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, TextIO, Tuple
+
+from .imports import Neo4Import, Neo4jImportWorker
 from .migrations import Migration
-from .migrations.migrate import migrate_db_schema, MigrationError
+from .migrations.migrate import MigrationError, migrate_db_schema
 from .migrations.migrations import (
     create_document_and_ne_id_unique_constraint_tx,
+    create_migration_unique_constraint_tx,
     create_migration_unique_constraint_tx,
 )
 

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -11,7 +11,6 @@ from .migrations.migrate import MigrationError, migrate_db_schema
 from .migrations.migrations import (
     create_document_and_ne_id_unique_constraint_tx,
     create_migration_unique_constraint_tx,
-    create_migration_unique_constraint_tx,
 )
 
 FIRST_MIGRATION = Migration(

--- a/neo4j-app/neo4j_app/core/neo4j/documents.py
+++ b/neo4j-app/neo4j_app/core/neo4j/documents.py
@@ -22,22 +22,13 @@ async def import_documents_from_csv_tx(
     #  iterateList:true}) to || and save memory import...
     query = f"""LOAD CSV WITH HEADERS FROM 'file:///{neo4j_import_path}' AS row
 MERGE (doc:{DOC_NODE} {{{DOC_ID}: row.{DOC_ID}}})
-ON CREATE
-    SET
-        doc.{DOC_CONTENT_TYPE} = row.{DOC_CONTENT_TYPE},
-        doc.{DOC_CONTENT_LENGTH} = toInteger(row.{DOC_CONTENT_LENGTH}),
-        doc.{DOC_EXTRACTION_DATE} = datetime(row.{DOC_EXTRACTION_DATE}),
-        doc.{DOC_DIRNAME} = row.{DOC_DIRNAME},
-        doc.{DOC_PATH} = row.{DOC_PATH},
-        doc.{DOC_ROOT_ID} = row.{DOC_ROOT_ID}
-ON MATCH
-    SET 
-        doc.{DOC_CONTENT_TYPE} = row.{DOC_CONTENT_TYPE},
-        doc.{DOC_CONTENT_LENGTH} = toInteger(row.{DOC_CONTENT_LENGTH}),
-        doc.{DOC_EXTRACTION_DATE} = datetime(row.{DOC_EXTRACTION_DATE}),
-        doc.{DOC_DIRNAME} = row.{DOC_DIRNAME},
-        doc.{DOC_PATH} = row.{DOC_PATH},
-        doc.{DOC_ROOT_ID} = row.{DOC_ROOT_ID}
+SET
+    doc.{DOC_CONTENT_TYPE} = row.{DOC_CONTENT_TYPE},
+    doc.{DOC_CONTENT_LENGTH} = toInteger(row.{DOC_CONTENT_LENGTH}),
+    doc.{DOC_EXTRACTION_DATE} = datetime(row.{DOC_EXTRACTION_DATE}),
+    doc.{DOC_DIRNAME} = row.{DOC_DIRNAME},
+    doc.{DOC_PATH} = row.{DOC_PATH},
+    doc.{DOC_ROOT_ID} = row.{DOC_ROOT_ID}
 """
     res = await tx.run(query)
     summary = await res.consume()

--- a/neo4j-app/neo4j_app/core/neo4j/imports.py
+++ b/neo4j-app/neo4j_app/core/neo4j/imports.py
@@ -1,0 +1,68 @@
+import asyncio
+import logging
+from functools import cached_property
+from typing import Any, Callable, Dict, List, Optional, Protocol
+
+import neo4j
+
+logger = logging.getLogger(__name__)
+
+
+class Neo4Import(Protocol):
+    async def __call__(
+        self,
+        neo4j_session: neo4j.AsyncSession,
+        records: List[Dict],
+        *,
+        transaction_batch_size: int,
+    ) -> neo4j.ResultSummary:
+        ...
+
+
+class Neo4jImportWorker:
+    def __init__(
+        self,
+        name: str,
+        neo4j_driver: neo4j.AsyncDriver,
+        import_fn: Neo4Import,
+        *,
+        transaction_batch_size: int,
+        to_neo4j_record: Optional[Callable[[Any], Dict]] = None,
+    ):
+        self._name = name
+        self._neo4j_driver = neo4j_driver
+        self._import_fn = import_fn
+        self._transaction_batch_size = transaction_batch_size
+        self._to_neo4j_record = to_neo4j_record
+
+    async def __call__(self, queue: asyncio.Queue) -> List[neo4j.ResultSummary]:
+        # TODO:
+        #  - use https://github.com/jd/tenacity to implement retry with backoff in
+        #  case of network error
+        #  - after several failure, requeue the job...
+        summaries = []
+        try:
+            while "Waiting forever until the task is cancelled":
+                import_batch = await queue.get()
+                if self._to_neo4j_record is not None:
+                    import_batch = [self._to_neo4j_record(r) for r in import_batch]
+                logger.debug("Worker %s is starting import...", self.name)
+                async with self._neo4j_driver.session() as neo4j_session:
+                    summary = await self._import_fn(
+                        neo4j_session,
+                        import_batch,
+                        transaction_batch_size=self._transaction_batch_size,
+                    )
+                logger.debug("Worker %s completed import !", self.name)
+                summaries.append(summary)
+                queue.task_done()
+        # Let's return
+        except asyncio.CancelledError:
+            logger.debug(
+                "Worker %s received cancellation signal, returning results", self.name
+            )
+            return summaries
+
+    @cached_property
+    def name(self) -> str:
+        return self._name

--- a/neo4j-app/neo4j_app/core/neo4j/imports.py
+++ b/neo4j-app/neo4j_app/core/neo4j/imports.py
@@ -46,7 +46,11 @@ class Neo4jImportWorker:
                 import_batch = await queue.get()
                 if self._to_neo4j_record is not None:
                     import_batch = [self._to_neo4j_record(r) for r in import_batch]
-                logger.debug("Worker %s is starting import...", self.name)
+                logger.debug(
+                    "Worker %s is starting import of %s records",
+                    self.name,
+                    len(import_batch),
+                )
                 async with self._neo4j_driver.session() as neo4j_session:
                     summary = await self._import_fn(
                         neo4j_session,

--- a/neo4j-app/neo4j_app/core/neo4j/named_entities.py
+++ b/neo4j-app/neo4j_app/core/neo4j/named_entities.py
@@ -27,28 +27,16 @@ WITH row, \
 [offset IN split(row.{NE_OFFSETS}, '{NE_OFFSET_SPLITCHAR}') | toInteger(offset)] \
 as rowOffsets  
 MERGE (mention:{NE_NODE} {{{NE_ID}: row.{NE_ID}}})
-ON CREATE
-    SET
-        mention.{NE_CATEGORY} = row.{NE_CATEGORY},
-        mention.{NE_DOC_ID} = row.{NE_DOC_ID},
-        mention.{NE_EXTRACTOR} = row.{NE_EXTRACTOR},
-        mention.{NE_EXTRACTOR_LANG} = row.{NE_EXTRACTOR_LANG},
-        mention.{NE_MENTION} = row.{NE_MENTION},
-        mention.{NE_MENTION_NORM} = row.{NE_MENTION_NORM},
-        mention.{NE_MENTION_NORM_TEXT_LENGTH} =\
-            toInteger(row.{NE_MENTION_NORM_TEXT_LENGTH}),
-        mention.{NE_OFFSETS} = rowOffsets
-ON MATCH
-    SET 
-        mention.{NE_CATEGORY} = row.{NE_CATEGORY},
-        mention.{NE_DOC_ID} = row.{NE_DOC_ID},
-        mention.{NE_EXTRACTOR} = row.{NE_EXTRACTOR},
-        mention.{NE_EXTRACTOR_LANG} = row.{NE_EXTRACTOR_LANG},
-        mention.{NE_MENTION} = row.{NE_MENTION},
-        mention.{NE_MENTION_NORM} = row.{NE_MENTION_NORM},
-        mention.{NE_MENTION_NORM_TEXT_LENGTH} =\
-            toInteger(row.{NE_MENTION_NORM_TEXT_LENGTH}),
-        mention.{NE_OFFSETS} = rowOffsets
+SET
+    mention.{NE_CATEGORY} = row.{NE_CATEGORY},
+    mention.{NE_DOC_ID} = row.{NE_DOC_ID},
+    mention.{NE_EXTRACTOR} = row.{NE_EXTRACTOR},
+    mention.{NE_EXTRACTOR_LANG} = row.{NE_EXTRACTOR_LANG},
+    mention.{NE_MENTION} = row.{NE_MENTION},
+    mention.{NE_MENTION_NORM} = row.{NE_MENTION_NORM},
+    mention.{NE_MENTION_NORM_TEXT_LENGTH} =\
+        toInteger(row.{NE_MENTION_NORM_TEXT_LENGTH}),
+    mention.{NE_OFFSETS} = rowOffsets
 """
     res = await tx.run(query)
     summary = await res.consume()

--- a/neo4j-app/neo4j_app/core/neo4j/named_entities.py
+++ b/neo4j-app/neo4j_app/core/neo4j/named_entities.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from typing import Dict, List
 
 import neo4j
 
@@ -8,36 +8,38 @@ from neo4j_app.constants import (
     NE_EXTRACTOR,
     NE_EXTRACTOR_LANG,
     NE_ID,
-    NE_NODE,
     NE_MENTION,
     NE_MENTION_NORM,
     NE_MENTION_NORM_TEXT_LENGTH,
+    NE_NODE,
     NE_OFFSETS,
-    NE_OFFSET_SPLITCHAR,
 )
 
 
-async def import_named_entities_from_csv_tx(
-    tx: neo4j.AsyncTransaction, neo4j_import_path: Path
+async def import_named_entity_rows(
+    neo4j_session: neo4j.AsyncSession,
+    records: List[Dict],
+    *,
+    transaction_batch_size: int,
 ) -> neo4j.ResultSummary:
-    # TODO: use apoc.periodic.iterate(.., ..., {batchSize:10000, parallel:true,
-    #  iterateList:true}) to || and save memory import...
-    query = f"""LOAD CSV WITH HEADERS FROM 'file:///{neo4j_import_path}' AS row
-WITH row, \
-[offset IN split(row.{NE_OFFSETS}, '{NE_OFFSET_SPLITCHAR}') | toInteger(offset)] \
-as rowOffsets  
-MERGE (mention:{NE_NODE} {{{NE_ID}: row.{NE_ID}}})
-SET
-    mention.{NE_CATEGORY} = row.{NE_CATEGORY},
-    mention.{NE_DOC_ID} = row.{NE_DOC_ID},
-    mention.{NE_EXTRACTOR} = row.{NE_EXTRACTOR},
-    mention.{NE_EXTRACTOR_LANG} = row.{NE_EXTRACTOR_LANG},
-    mention.{NE_MENTION} = row.{NE_MENTION},
-    mention.{NE_MENTION_NORM} = row.{NE_MENTION_NORM},
-    mention.{NE_MENTION_NORM_TEXT_LENGTH} =\
-        toInteger(row.{NE_MENTION_NORM_TEXT_LENGTH}),
-    mention.{NE_OFFSETS} = rowOffsets
+    # TODO: use apoc.periodic.iterate(parallel:true, iterateList:true}) to || and speed
+    #  up import...
+    query = f"""UNWIND $rows AS row
+CALL {{
+    WITH row
+    MERGE (mention:{NE_NODE} {{{NE_ID}: row.{NE_ID}}})
+    SET
+        mention.{NE_CATEGORY} = row.{NE_CATEGORY},
+        mention.{NE_DOC_ID} = row.{NE_DOC_ID},
+        mention.{NE_EXTRACTOR} = row.{NE_EXTRACTOR},
+        mention.{NE_EXTRACTOR_LANG} = row.{NE_EXTRACTOR_LANG},
+        mention.{NE_MENTION} = row.{NE_MENTION},
+        mention.{NE_MENTION_NORM} = row.{NE_MENTION_NORM},
+        mention.{NE_MENTION_NORM_TEXT_LENGTH} =\
+            toInteger(row.{NE_MENTION_NORM_TEXT_LENGTH}),
+        mention.{NE_OFFSETS} = row.{NE_OFFSETS}
+}} IN TRANSACTIONS OF $batchSize ROWS
 """
-    res = await tx.run(query)
+    res = await neo4j_session.run(query, rows=records, batchSize=transaction_batch_size)
     summary = await res.consume()
     return summary

--- a/neo4j-app/neo4j_app/run/run.py
+++ b/neo4j-app/neo4j_app/run/run.py
@@ -1,6 +1,5 @@
 # TODO: rename this into run_http ?
 import argparse
-import os
 import sys
 from pathlib import Path
 from typing import Optional
@@ -10,15 +9,9 @@ import uvicorn
 from neo4j_app.app.utils import create_app
 from neo4j_app.core.config import AppConfig
 
-DATA_DIR = Path(__file__).parents[3].joinpath(".data")
-NEO4J_TEST_IMPORT_DIR = DATA_DIR.joinpath("neo4j", "import")
-NEO4J_IMPORT_PREFIX = Path(os.sep).joinpath(".neo4j", "import")
-
 
 def debug_app():
-    neo4j_import_dir = Path(__file__).parents[4].joinpath(".data", "neo4j", "import")
     config = AppConfig(
-        neo4j_import_dir=str(neo4j_import_dir),
         neo4j_project="Debug project",
     )
     app = create_app(config)
@@ -46,8 +39,6 @@ def _start_app(config_path: Optional[str] = None, force_migrations: bool = False
     else:
         config = AppConfig(
             neo4j_project="test-datashare-project",
-            neo4j_import_dir=str(NEO4J_TEST_IMPORT_DIR),
-            neo4j_import_prefix=str(NEO4J_IMPORT_PREFIX),
         )
     app = create_app(config)
     uvicorn_config = config.to_uvicorn()

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_imports.py
@@ -1,0 +1,66 @@
+import asyncio
+from typing import Dict, List
+
+import neo4j
+import pytest
+
+from neo4j_app.core.neo4j import Neo4jImportWorker
+
+
+async def _dummy_import(
+    neo4j_session: neo4j.AsyncSession,
+    records: List[Dict],
+    *,
+    transaction_batch_size: int,
+) -> neo4j.ResultSummary:
+    query = """
+UNWIND $rows as row
+CALL {
+    WITH row
+    MERGE (node:DummyNode {nodeId: row.id})
+    SET node.nodeId = row.id
+} IN TRANSACTIONS OF $batchSize ROWS
+"""
+    res = await neo4j_session.run(query, rows=records, batchSize=transaction_batch_size)
+    summary = await res.consume()
+    return summary
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("num_workers", [1, 2])
+async def test_neo4_import_worker(
+    num_workers: int, neo4j_test_driver: neo4j.AsyncDriver
+):
+    # Given
+    neo4j_driver = neo4j_test_driver
+    transaction_batch_size = 2
+    num_records = 22
+    import_batch_size = 3
+    records = [{"id": f"id-{i}"} for i in range(num_records)]
+    workers = [
+        Neo4jImportWorker(
+            f"worker-{i}",
+            neo4j_driver=neo4j_driver,
+            import_fn=_dummy_import,
+            transaction_batch_size=transaction_batch_size,
+        )
+        for i in range(num_workers)
+    ]
+    queue = asyncio.Queue()
+    for start in range(0, num_records, import_batch_size):
+        queue.put_nowait(records[start : start + import_batch_size])
+
+    # When
+    worker_tasks = [asyncio.create_task(worker(queue)) for worker in workers]
+    # Wait for queue to be processed
+    await queue.join()
+    for task in worker_tasks:
+        # Cancel tasks
+        task.cancel()
+    # Wait for tasks be collect results
+    summaries = await asyncio.gather(*worker_tasks)
+    summaries = sum(summaries, [])
+
+    # Then
+    num_created = sum(summary.counters.nodes_created for summary in summaries)
+    assert num_created == num_records

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
@@ -4,11 +4,8 @@ import pytest
 from neo4j_app.core.elasticsearch.to_neo4j import (
     es_to_neo4j_named_entity,
 )
-from neo4j_app.core.neo4j import make_neo4j_import_file, write_neo4j_csv
-from neo4j_app.core.neo4j.named_entities import import_named_entities_from_csv_tx
+from neo4j_app.core.neo4j.named_entities import import_named_entity_rows
 from neo4j_app.tests.conftest import (
-    NEO4J_IMPORT_PREFIX,
-    NEO4J_TEST_IMPORT_DIR,
     make_named_entities,
 )
 
@@ -19,52 +16,35 @@ async def test_import_named_entities(
     neo4j_test_session: neo4j.AsyncSession, n_existing: int
 ):
     # Given
+    transaction_batch_size = 3
     num_ents = 3
     ents = list(make_named_entities(n=num_ents))
 
-    headers = [
-        "id",
-        "documentId",
-        "offsets",
-    ]
     # When
     n_created_first = 0
     if n_existing:
-        with make_neo4j_import_file(
-            neo4j_import_dir=NEO4J_TEST_IMPORT_DIR,
-            neo4j_import_prefix=str(NEO4J_IMPORT_PREFIX),
-        ) as (
-            f,
-            neo4j_path,
-        ):
-            rows = (es_to_neo4j_named_entity(ent) for ent in ents[:n_existing])
-            write_neo4j_csv(f, rows=rows, header=headers, write_header=True)
-            f.flush()
-            summary = await neo4j_test_session.execute_write(
-                import_named_entities_from_csv_tx, neo4j_import_path=neo4j_path
-            )
-            n_created_first = summary.counters.nodes_created
-    with make_neo4j_import_file(
-        neo4j_import_dir=NEO4J_TEST_IMPORT_DIR,
-        neo4j_import_prefix=str(NEO4J_IMPORT_PREFIX),
-    ) as (
-        f,
-        neo4j_path,
-    ):
-        rows = (es_to_neo4j_named_entity(ent) for ent in ents)
-        write_neo4j_csv(f, rows=rows, header=headers, write_header=True)
-        f.flush()
-        summary = await neo4j_test_session.execute_write(
-            import_named_entities_from_csv_tx, neo4j_import_path=neo4j_path
+        records = [es_to_neo4j_named_entity(ent) for ent in ents[:n_existing]]
+        summary = await import_named_entity_rows(
+            neo4j_test_session,
+            records=records,
+            transaction_batch_size=transaction_batch_size,
         )
-        n_created_second = summary.counters.nodes_created
+        n_created_first = summary.counters.nodes_created
+    records = [es_to_neo4j_named_entity(ent) for ent in ents]
+    summary = await import_named_entity_rows(
+        neo4j_test_session,
+        records=records,
+        transaction_batch_size=transaction_batch_size,
+    )
+    n_created_second = summary.counters.nodes_created
 
     # Then
     assert n_created_first == n_existing
     assert n_created_second == num_ents - n_existing
     query = """
 MATCH (ent:NamedEntity)
-RETURN ent as ent"""
+RETURN ent as ent
+ORDER BY ent.id"""
     res = await neo4j_test_session.run(query)
     ents = [dict(rec["ent"]) async for rec in res]
     expected_ents = [
@@ -81,6 +61,7 @@ async def test_import_named_entities_should_update_named_entity(
 ):
     # Given
     num_ents = 1
+    transaction_batch_size = 3
     ents = list(make_named_entities(n=num_ents))
     query = """
 CREATE (n:NamedEntity {id: 'named-entity-0', offsets: [1, 2], documentId: 'doc-0'})
@@ -88,24 +69,12 @@ CREATE (n:NamedEntity {id: 'named-entity-0', offsets: [1, 2], documentId: 'doc-0
     await neo4j_test_session.run(query)
 
     # When
-    headers = [
-        "id",
-        "documentId",
-        "offsets",
-    ]
-    with make_neo4j_import_file(
-        neo4j_import_dir=NEO4J_TEST_IMPORT_DIR,
-        neo4j_import_prefix=str(NEO4J_IMPORT_PREFIX),
-    ) as (
-        f,
-        neo4j_path,
-    ):
-        rows = (es_to_neo4j_named_entity(ent) for ent in ents)
-        write_neo4j_csv(f, rows=rows, header=headers, write_header=True)
-        f.flush()
-        await neo4j_test_session.execute_write(
-            import_named_entities_from_csv_tx, neo4j_import_path=neo4j_path
-        )
+    records = [es_to_neo4j_named_entity(ent) for ent in ents]
+    await import_named_entity_rows(
+        neo4j_test_session,
+        records=records,
+        transaction_batch_size=transaction_batch_size,
+    )
 
     # Then
     query = """


### PR DESCRIPTION
# TODO
- [x] merge #24 first

# PR description

Fixes #27

This PR avoids relying on the filesystem in order to perform incremental imports. The main reason for not relying on the filesystem it that we don't control the available disk space on the host machine and hence large import might fail.

Instead of exporting data from ES to CSV files, the incremental import are now performed fully in-memory in a "streaming" fashion.

## Context

The import was implemented with the following data points in mind:
- fetching data from ES is done in small pages (compared to the total import size)
- polling pages from ES is taking longer than inserting data into neo4j
- memory on the host machine is not unlimited, the size of the streaming buffer must be controlled
- ES, neo4j support concurrent import/export

## Chosen implementation

The import was implemented using the producer-consumer pattern leveraging an `asyncio.Queue`:
- data is concurrently polled from ES using the already implement PIT search with slice. Each slice poller acts as a producer
- since neo4j can perform large import efficiently it's not to necessary to import each page return by the pollers right away
- hence the ES producer fill a shared import buffer until it reaches the `neo4j_import_batch_size` size, at this point an import batch is created and added to the task queue
- several `Neo4jImportWorker`s run and will perfom the import concurrently and act as consumers, consuming import batches each time new ones are available in the queue
- in order to control memory footprint the import queue can't be filler endlessly, task can be added to it until it reaches `neo4j_app_max_records_in_memory`, at this point the streaming waits for batches to be imported and the queue to be smaller
- the import stops when producers have finished polling pages and consumers have consumed all import batches from the queue

Additionnally in case the `neo4j_import_batch_size` is set to be large, the `neo4j_transaction_batch_size` has been introduce in order to batch the import into smaller `neo4j` transactions.

## Performance

This implementation yields a `20%` speedup comparing on the implementation relying on the file system.


# Changes

## `datashare-extension-neo4j/neo4j-app`

### Added
- Implemented the  `Neo4jImportWorker` which consumes an `asyncio.Queue` and perform neo4j import
- Added the `ESClientABC.to_neo4j` method which given a elastic search query to import, creates a new task queue, import bufffer, launches ES producers and `Neo4jImportWorker` consumers to perform the import
