### PR TITLE
fix: restrict `/admin/neo4j-csvs` to local user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>datashare-api</artifactId>
-            <version>8.7.3</version>
+            <version>10.0.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -184,6 +184,7 @@ public class Neo4jResource {
     //CHECKSTYLE.OFF: AbbreviationAsWordInName
     @Post("/admin/neo4j-csvs?project=:project")
     public Payload postNeo4jCSVs(String project, Context context) throws IOException {
+        checkCheckLocal();
         checkAccess(project, context);
         org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest request =
             context.extract(org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest.class);
@@ -421,8 +422,15 @@ public class Neo4jResource {
         }
     }
 
-    private void checkAccess(String project, Context context) {
+    protected void checkAccess(String project, Context context) {
         if (!((User) context.currentUser()).isGranted(project)) {
+            throw new UnauthorizedException();
+        }
+    }
+
+    protected void checkCheckLocal() {
+        String mode = propertiesProvider.get("mode").orElse("SERVER");
+        if (!mode.equals("LOCAL") && !mode.equals("EMBEDDED")) {
             throw new UnauthorizedException();
         }
     }


### PR DESCRIPTION
# Before merging
- [x] merge #31

# PR description

This PR aims as restricting the use of `POST /admin/neo4j-csvs` to the `LOCAL` model