### PR TITLE
feature: implement a reconnecting AMQP `MessageConsumer`

### DIFF
--- a/neo4j-app/neo4j_app/icij_worker/consumer.py
+++ b/neo4j-app/neo4j_app/icij_worker/consumer.py
@@ -1,0 +1,505 @@
+# Mostly inspired by
+# https://github.com/pika/pika/blob/main/examples/asyncio_consumer_example.py
+import functools
+import logging
+import signal
+import threading
+import time
+from typing import Callable, Dict, Optional, Tuple, Type
+
+import pika
+from astroid.decorators import cachedproperty
+from pika import BaseConnection, BasicProperties, SelectConnection
+from pika.channel import Channel
+from pika.exceptions import (
+    StreamLostError,
+)
+from pika.exchange_type import ExchangeType
+from pika.frame import Method
+from pika.spec import Basic
+
+from neo4j_app.icij_worker.exceptions import (
+    MaxReconnectionExceeded,
+)
+from neo4j_app.icij_worker.utils import LogWithNameMixin, parse_stream_lost_error
+
+_IOLOOP_ALREADY_RUNNING_MSG = "is already running"
+
+logger = logging.getLogger(__name__)
+
+
+class _MessageConsumer(LogWithNameMixin):
+    _EXCHANGE_TYPE = ExchangeType.topic
+    _logger = logger
+
+    def __init__(
+        self,
+        *,
+        on_message: Callable,
+        name: str,
+        exchange: str,
+        broker_url: str,
+        queue: str,
+        routing_key: str,
+        app_id: Optional[str] = None,
+        recover_from: Tuple[Type[Exception], ...] = tuple(),
+    ):
+        self._on_message = on_message
+
+        self._name = name
+
+        self._exchange = exchange
+        self._queue = queue
+        self._routing_key = routing_key
+        self._app_id = app_id
+        self._broker_url = broker_url
+        self._recover_from = recover_from
+
+        self._connection_ = None
+        self._channel_ = None
+        self._error = None
+
+        self._should_reconnect = False
+        self._closing = False
+        self._consumer_tag = None
+        self._consuming = False
+        self._last_message_received_at = None
+        # TODO: for now prefetch factor is disabled, for short tasks this might be
+        #  helpful for a higher consumer throughput
+        self._prefetch_count = 1
+
+    @property
+    def logged_name(self) -> str:
+        return f"{self._name} (tag: {self.consumer_tag})"
+
+    @property
+    def should_reconnect(self) -> bool:
+        return self._should_reconnect
+
+    @property
+    def error(self) -> Optional[Exception]:
+        return self._error
+
+    @property
+    def last_message_received_at(self) -> Optional[float]:
+        return self._last_message_received_at
+
+    @property
+    def consumer_tag(self) -> Optional[str]:
+        return self._consumer_tag
+
+    @property
+    def _connection(self) -> SelectConnection:
+        if self._connection_ is None:
+            msg = (
+                f"consumer has no connection, please call"
+                f" {_MessageConsumer.connect.__name__}"
+            )
+            raise ValueError(msg)
+        return self._connection_
+
+    @property
+    def _channel(self) -> Channel:
+        if self._channel_ is None:
+            msg = (
+                f"consumer has no channel, please call"
+                f" {_MessageConsumer.connect.__name__}"
+            )
+            raise ValueError(msg)
+        return self._channel_
+
+    @cachedproperty
+    def _exception_namespace(self) -> Dict:
+        ns = dict(globals())
+        ns.update({exc_type.__name__: exc_type for exc_type in self._recover_from})
+        return ns
+
+    def connect(self):
+        self._log(logging.DEBUG, "connecting to %s", self._broker_url)
+        # TODO: heartbeat ? blocked connection timeout ?
+        self._connection_ = SelectConnection(
+            parameters=pika.URLParameters(self._broker_url),
+            on_open_callback=self._on_connection_open,
+            on_open_error_callback=self._on_connection_open_error,
+            on_close_callback=self._on_connection_closed,
+        )
+
+    def on_message(
+        self,
+        _unused_channel: Channel,  # pylint: disable=invalid-name
+        basic_deliver: Basic.Deliver,
+        _properties: BasicProperties,  # pylint: disable=invalid-name
+        body: bytes,
+    ):
+        self._last_message_received_at = time.monotonic()
+        msg = "received message # %s"
+        if self._app_id is not None:
+            msg = f"{msg} from {self._app_id}"
+        self._log(logging.DEBUG, msg, basic_deliver.delivery_tag)
+        self._on_message(body)
+        self._acknowledge_message(basic_deliver.delivery_tag)
+
+    def consume(self):
+        self.connect()
+        self._connection.ioloop.start()
+
+    def stop(self):
+        if not self._closing:
+            self._closing = True
+            self._log(logging.INFO, "stopping...")
+            if self._consuming:
+                # The IOLoop is started again because this method is invoked  when
+                # CTRL-C is pressed raising a KeyboardInterrupt exception. This
+                # exception stops the IOLoop which needs to be running for pika to
+                # communicate with RabbitMQ. All the commands issued prior to
+                # starting the IOLoop will be buffered but not processed.
+                self._stop_consuming()
+                # Calling start will fail if the loop is already running
+                try:
+                    self._connection.ioloop.start()
+                # not robust, but sadly pika does not provide a more catchable
+                # exception type...
+                except RuntimeError as e:
+                    if _IOLOOP_ALREADY_RUNNING_MSG not in str(e):
+                        raise e
+            else:
+                if self._connection_ is not None:
+                    self._connection.ioloop.stop()
+            self._log(logging.INFO, "stopped !")
+
+    def _trigger_reconnect(self):
+        self._should_reconnect = True
+
+    def _stop_consuming(self):
+        if self._channel:
+            self._log(logging.DEBUG, "sending a Basic.Cancel RPC command to RabbitMQ")
+            self._channel.basic_cancel(self.consumer_tag, self._on_cancelok)
+
+    def _acknowledge_message(self, delivery_tag: int):
+        self._log(logging.DEBUG, "acknowledging message %s", delivery_tag)
+        self._channel.basic_ack(delivery_tag)
+
+    def _close_connection(self):
+        self._consuming = False
+        if self._connection.is_closing or self._connection.is_closed:
+            self._log(logging.DEBUG, "connection is closing or already closed")
+        else:
+            self._log(logging.DEBUG, "closing connection")
+            self._connection.close()
+
+    def _on_connection_open(self, _unused_connection: BaseConnection):
+        # pylint: disable=invalid-name
+        self._log(logging.DEBUG, "connection opened !")
+        self._open_channel()
+
+    def _on_connection_open_error(
+        self, _unused_connection: BaseConnection, err: Exception
+    ):
+        # pylint: disable=invalid-name
+        self._parse_error(err)
+        if isinstance(self._error, StreamLostError):
+            self._log(
+                logging.WARNING, "failed to parse stream lost internal error: %s", err
+            )
+        self._log(logging.ERROR, "connection open failed: %s", self._error)
+        if isinstance(self._error, self._recover_from):
+            self._log(logging.ERROR, "triggering reconnection !")
+            self._trigger_reconnect()
+        self.stop()
+
+    def _on_connection_closed(
+        self, _unused_connection: BaseConnection, reason: Exception
+    ):
+        # pylint: disable=invalid-name
+        self._parse_error(reason)
+        self._channel_ = None
+        if self._closing:  # The connection was closed on purpose
+            self._connection.ioloop.stop()
+        else:
+            self._log(logging.ERROR, "connection was accidentally closed: %s", reason)
+            if isinstance(self._error, self._recover_from):
+                self._log(logging.ERROR, "triggering reconnection !")
+                self._trigger_reconnect()
+            self.stop()
+
+    def _open_channel(self):
+        self._log(logging.DEBUG, "creating a new channel")
+        self._connection.channel(on_open_callback=self._on_channel_open)
+
+    def _on_channel_open(self, channel: Channel):
+        self._log(logging.DEBUG, "channel opened !")
+        self._channel_ = channel
+        self._add_on_channel_close_callback()
+        self._setup_exchange()
+
+    def _add_on_channel_close_callback(self):
+        self._channel.add_on_close_callback(self._on_channel_closed)
+
+    def _on_channel_closed(self, channel: Channel, reason: Exception):
+        self._log(
+            logging.WARNING, "channel %s was closed: %s", channel.channel_number, reason
+        )
+        self._close_connection()
+
+    def _setup_exchange(self):
+        self._log(logging.DEBUG, "declaring exchange: %s", self._exchange)
+        self._channel.exchange_declare(
+            exchange=self._exchange,
+            exchange_type=self._EXCHANGE_TYPE,
+            callback=self._on_exchange_declareok,
+            durable=True,
+        )
+
+    def _on_exchange_declareok(self, _unused_frame: Method):
+        # pylint: disable=invalid-name
+        self._log(logging.DEBUG, "exchange %s declared", self._exchange)
+        self._setup_queue()
+
+    def _setup_queue(self):
+        self._log(logging.DEBUG, "declaring queue %s", self._queue)
+        self._channel.queue_declare(
+            queue=self._queue, callback=self._on_queue_declareok, durable=True
+        )
+
+    def _on_queue_declareok(self, _unused_frame: Method):
+        # pylint: disable=invalid-name
+        self._log(
+            logging.INFO,
+            "binding %s to %s with %s",
+            self._exchange,
+            self._queue,
+            self._routing_key,
+        )
+        self._channel.queue_bind(
+            self._queue,
+            self._exchange,
+            routing_key=self._routing_key,
+            callback=self._on_bindok,
+        )
+
+    def _on_bindok(self, _unused_frame: Method):
+        # pylint: disable=invalid-name
+        self._log(logging.DEBUG, "queue %s bound", self._queue)
+        self._set_qos()
+
+    def _set_qos(self):
+        self._channel.basic_qos(
+            prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok
+        )
+
+    def _on_basic_qos_ok(self, _unused_frame: Method):
+        # pylint: disable=invalid-name
+        self._log(logging.DEBUG, "QOS set to: %d", self._prefetch_count)
+        self._start_consuming()
+
+    def _start_consuming(self):
+        self._log(logging.INFO, "starting consuming...")
+        self._add_on_cancel_callback()
+        self._consumer_tag = self._channel.basic_consume(
+            self._queue, self.on_message, consumer_tag=self.consumer_tag
+        )
+        self._consuming = True
+
+    def _add_on_cancel_callback(self):
+        self._log(logging.DEBUG, "adding consumer cancellation callback")
+        self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
+
+    def _on_consumer_cancelled(self, method_frame: Method):
+        # pylint: disable=invalid-name
+        self._log(
+            logging.ERROR,
+            "consumer was cancelled remotely, shutting down: %r",
+            method_frame,
+        )
+        if self._channel:
+            self._channel.close()
+        raise KeyboardInterrupt()
+
+    def _on_cancelok(self, _unused_frame: Method):
+        # pylint: disable=invalid-name
+        self._consuming = False
+        self._log(
+            logging.INFO,
+            "RabbitMQ acknowledged the cancellation of the consumer",
+        )
+        self._close_channel()
+        self._log(logging.INFO, "exiting consumer execution after cancellation")
+
+    def _close_channel(self):
+        self._log(logging.DEBUG, "closing the channel")
+        self._channel.close()
+
+    def _parse_error(self, error: Exception):
+        if isinstance(error, StreamLostError):
+            self._error = parse_stream_lost_error(
+                error, namespace=self._exception_namespace
+            )
+            if isinstance(self._error, StreamLostError):
+                self._log(
+                    logging.WARNING,
+                    "failed to parse internal stream lost error %s",
+                    error,
+                )
+        else:
+            self._error = error
+
+
+class MessageConsumer(LogWithNameMixin):
+    _logger = logger
+
+    def __init__(
+        self,
+        *,
+        on_message: Callable,
+        name: str,
+        exchange: str,
+        broker_url: str,
+        queue: str,
+        routing_key: str,
+        app_id: Optional[str] = None,
+        recover_from: Tuple[Type[Exception], ...] = tuple(),
+        max_connection_wait_s: float = 60.0,
+        max_connection_attempts: int = 5,
+        inactive_after_s: float = 60 * 60,
+    ):
+        self._on_message = on_message
+        self._name = name
+        self._exchange = exchange
+        self._broker_url = broker_url
+        self._queue = queue
+        self._routing_key = routing_key
+        self._app_id = app_id
+        self._recover_from = recover_from
+
+        self._consumer = self._create_consumer()
+
+        self._connection_attempt = 0
+        self._max_wait_s = max_connection_wait_s
+        self._max_attempts = max_connection_attempts
+        # Before inactive_after_s second of activity the consumer is considered active
+        # and we'll try to reconnect immediately. After that delay, we'll try to
+        # reconnect at most max_connection_attempts
+        self._inactive_after_s = inactive_after_s
+
+        self._stop_gracefully = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    @property
+    def logged_name(self) -> str:
+        return self._consumer.logged_name
+
+    @property
+    def consumer_tag(self) -> Optional[str]:
+        return self._consumer.consumer_tag
+
+    @property
+    def _is_active(self) -> bool:
+        if self._consumer.last_message_received_at is not None:
+            elapsed = time.monotonic() - self._consumer.last_message_received_at
+            return elapsed < self._inactive_after_s
+        return False
+
+    def consume(self):
+        logger.info("starting consuming...")
+        self._setup_signal_handlers()
+        try:
+            while True:
+                self._consumer.consume()
+                # ioloop.stop() has been called, let's see if we should reconnect
+                self._try_reconnect()
+        except KeyboardInterrupt:
+            self._log(logging.INFO, "shutting down...")
+        except Exception as e:
+            self._log(logging.ERROR, "error occurred while consuming: %s", e)
+            self._log(logging.INFO, "will try to shutdown gracefully...")
+            self._stop_gracefully = True
+            raise e
+        finally:
+            self.close()
+
+    def close(self):
+        if self._stop_gracefully:
+            self._log(logging.INFO, "shutting down gracefully...")
+            self._consumer.stop()
+        else:
+            self._log(logging.INFO, "shutting down the hard way...")
+
+    def _create_consumer(self) -> _MessageConsumer:
+        return _MessageConsumer(
+            on_message=self._on_message,
+            name=self._name,
+            exchange=self._exchange,
+            broker_url=self._broker_url,
+            queue=self._queue,
+            routing_key=self._routing_key,
+            app_id=self._app_id,
+            recover_from=self._recover_from,
+        )
+
+    def _try_reconnect(self):
+        # if the consumer was already consuming, many AMQP steps occurred, the
+        # disconnect occurred after a while, we can reset the connection attempt. If
+        # the consumer didn't to this point we don't want to retry connecting forever,
+        # we hence increment the counter
+        if self._is_active:
+            self._connection_attempt = 0
+        error = self._consumer.error
+        if self._consumer.should_reconnect:
+            self._connection_attempt += 1
+            if self._connection_attempt > self._max_attempts:
+                msg = f"consumer exceeded {self._max_attempts} reconnections"
+                try:
+                    raise MaxReconnectionExceeded(msg)
+                except MaxReconnectionExceeded as max_retry_exc:
+                    raise error from max_retry_exc
+            self._consumer.stop()
+            reconnect_delay = self._get_reconnect_delay()
+            self._log(
+                logging.INFO,
+                "reconnection attempt %i, reconnecting after %ds",
+                self._connection_attempt,
+                reconnect_delay,
+            )
+            time.sleep(reconnect_delay)
+            self._consumer = self._create_consumer()
+        else:
+            self._log(
+                logging.ERROR, "consumer encountered non recoverable error %s", error
+            )
+            raise error
+
+    def _get_reconnect_delay(self) -> float:
+        try:
+            exp = 2 ** (self._connection_attempt - 1)
+            result = 1 * exp
+        except OverflowError:
+            return self._max_wait_s
+        return max(0, min(result, self._max_wait_s))
+
+    def _signal_handler(
+        self,
+        signal_name: str,
+        _,
+        __,  # pylint: disable=invalid-name
+        *,
+        graceful: bool,
+    ):
+        self._log(logging.ERROR, "received %s", signal_name)
+        self._stop_gracefully = graceful
+        raise KeyboardInterrupt()
+
+    def _setup_signal_handlers(self):
+        if threading.current_thread() is threading.main_thread():
+            signal.signal(
+                signal.SIGINT,
+                functools.partial(self._signal_handler, "SIGINT", graceful=True),
+            )
+            signal.signal(
+                signal.SIGTERM,
+                functools.partial(self._signal_handler, "SIGTERM", graceful=False),
+            )

--- a/neo4j-app/neo4j_app/icij_worker/consumer.py
+++ b/neo4j-app/neo4j_app/icij_worker/consumer.py
@@ -5,10 +5,10 @@ import logging
 import signal
 import threading
 import time
+from functools import cached_property
 from typing import Callable, Dict, Optional, Tuple, Type
 
 import pika
-from astroid.decorators import cachedproperty
 from pika import BaseConnection, BasicProperties, SelectConnection
 from pika.channel import Channel
 from pika.exceptions import (
@@ -108,7 +108,7 @@ class _MessageConsumer(LogWithNameMixin):
             raise ValueError(msg)
         return self._channel_
 
-    @cachedproperty
+    @cached_property
     def _exception_namespace(self) -> Dict:
         ns = dict(globals())
         ns.update({exc_type.__name__: exc_type for exc_type in self._recover_from})

--- a/neo4j-app/neo4j_app/tests/icij_worker/conftest.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/conftest.py
@@ -61,7 +61,7 @@ def test_management_url(url: str) -> str:
 
 async def _wipe_rabbit_mq():
     async with aiohttp.ClientSession(
-            raise_for_status=True, auth=_DEFAULT_AUTH
+        raise_for_status=True, auth=_DEFAULT_AUTH
     ) as session:
         await _delete_all_connections(session)
         tasks = [_delete_all_exchanges(session), _delete_all_queues(session)]
@@ -112,10 +112,10 @@ async def _delete_queue(session: aiohttp.ClientSession, name: str):
 
 
 def true_after(
-        state_statement: Callable,
-        *,
-        after_s: float,
-        sleep_s: float = 0.01,
+    state_statement: Callable,
+    *,
+    after_s: float,
+    sleep_s: float = 0.01,
 ) -> bool:
     start = monotonic()
     while "waiting for the statement to be True":

--- a/neo4j-app/neo4j_app/tests/icij_worker/consumer_main.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/consumer_main.py
@@ -1,0 +1,29 @@
+import logging
+import sys
+
+from neo4j_app import icij_worker
+from neo4j_app.icij_worker.consumer import MessageConsumer
+
+_FMT = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: %(message)s"
+_DATE_FMT = "%H:%M:%S"
+
+
+if __name__ == "__main__":
+    # Setup logger main logger
+    broker_url = sys.argv[1]
+    loggers = ["__main__", icij_worker.__name__]
+    for logger in loggers:
+        logger = logging.getLogger(logger)
+        logger.setLevel(logging.DEBUG)
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(_FMT, datefmt=_DATE_FMT))
+        logger.addHandler(handler)
+    consumer = MessageConsumer(
+        name="test-worker",
+        on_message=lambda: print("working"),
+        broker_url=broker_url,
+        queue="test-queue",
+        exchange="default-ex",
+        routing_key="test",
+    )
+    consumer.consume()

--- a/neo4j-app/neo4j_app/tests/icij_worker/test_consumer.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/test_consumer.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import signal
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from pathlib import Path
+from subprocess import PIPE, Popen
+from typing import Type
+
+import pytest
+from pika import (
+    BasicProperties,
+    BlockingConnection,
+    DeliveryMode,
+    URLParameters,
+)
+from pika.channel import Channel
+from pika.exceptions import StreamLostError
+from pika.spec import Basic
+
+from neo4j_app.icij_worker.consumer import MessageConsumer, _MessageConsumer
+from neo4j_app.icij_worker.exceptions import ConnectionLostError
+from neo4j_app.tests.icij_worker.conftest import true_after
+
+
+def _do_nothing(_: bytes):
+    pass
+
+
+@contextmanager
+def _shutdown_nowait(executor: ThreadPoolExecutor):
+    try:
+        yield executor
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
+
+
+class _TestConsumer_(_MessageConsumer):  # pylint: disable=invalid-name
+    n_failures: int = 0
+    consumed = 0
+
+    def on_message(
+        self,
+        _unused_channel: Channel,
+        basic_deliver: Basic.Deliver,
+        properties: BasicProperties,
+        body: bytes,
+    ):
+        # pylint: disable=arguments-renamed
+        super().on_message(_unused_channel, basic_deliver, properties, body)
+        self.consumed += 1
+
+
+def _consumer_factory(consumer_cls: Type[_TestConsumer_], n_failures: int) -> Type:
+    consumer_cls.n_failures = n_failures
+
+    class TestConsumer(MessageConsumer):
+        @property
+        def consumed(self) -> int:
+            return self._consumer.consumed
+
+        @property
+        def consumer(self) -> _TestConsumer_:
+            return self._consumer
+
+        def _create_consumer(self) -> _TestConsumer_:
+            return consumer_cls(
+                on_message=self._on_message,
+                name=self._name,
+                exchange=self._exchange,
+                broker_url=self._broker_url,
+                queue=self._queue,
+                routing_key=self._routing_key,
+                app_id=self._app_id,
+                recover_from=self._recover_from,
+            )
+
+    return TestConsumer
+
+
+class _FatalError(ValueError):
+    ...
+
+
+class _RecoverableError(ValueError):
+    ...
+
+
+class _ConnectionLostConsumer_(_TestConsumer_):  # pylint: disable=invalid-name
+    def on_message(
+        self,
+        _unused_channel: Channel,
+        basic_deliver: Basic.Deliver,
+        properties: BasicProperties,
+        body: bytes,
+    ):
+        self._last_message_received_at = time.monotonic()
+        if self.__class__.n_failures:
+            self.__class__.n_failures -= 1
+            self._connection._proto_eof_received()  # pylint: disable=protected-access
+        super().on_message(_unused_channel, basic_deliver, properties, body)
+
+
+class _RecoverableErrorConsumer_(_TestConsumer_):  # pylint: disable=invalid-name
+    def on_message(
+        self,
+        _unused_channel: Channel,
+        basic_deliver: Basic.Deliver,
+        properties: BasicProperties,
+        body: bytes,
+    ):
+        self._last_message_received_at = time.monotonic()
+        if self.__class__.n_failures:
+            self.__class__.n_failures -= 1
+            raise _RecoverableError("i can recover from this")
+        super().on_message(_unused_channel, basic_deliver, properties, body)
+
+
+class _FatalErrorConsumer_(_TestConsumer_):  # pylint: disable=invalid-name
+    def on_message(
+        self,
+        _unused_channel: Channel,
+        basic_deliver: Basic.Deliver,
+        properties: BasicProperties,
+        body: bytes,
+    ):
+        raise _FatalError("this is too fatal i can't recover from this")
+
+
+def test_consumer_should_consume(
+    rabbit_mq: str,
+    amqp_loggers,  # pylint: disable=unused-argument
+):
+    # Given
+    broker_url = rabbit_mq
+    queue = "test-queue"
+    exchange = "default-ex"
+    routing_key = "test"
+    consumer_cls = _consumer_factory(_TestConsumer_, n_failures=0)
+    consumer = consumer_cls(
+        on_message=_do_nothing,
+        name="test-consumer",
+        exchange=exchange,
+        broker_url=broker_url,
+        queue=queue,
+        routing_key=routing_key,
+        max_connection_wait_s=0.1,
+        max_connection_attempts=5,
+    )
+
+    with _shutdown_nowait(ThreadPoolExecutor()) as executor:
+        with consumer:
+            executor.submit(consumer.consume)
+            # When
+            with BlockingConnection(URLParameters(broker_url)) as connection:
+                with connection.channel() as channel:
+                    channel.basic_publish(
+                        exchange,
+                        routing_key,
+                        b"",
+                        BasicProperties(
+                            content_type="text/plain",
+                            delivery_mode=DeliveryMode.Transient,
+                        ),
+                    )
+
+                # Then
+                after_s = 1.0
+                statement = (
+                    lambda: consumer.consumed  # pylint: disable=unnecessary-lambda-assignment
+                )
+                msg = f"consumer failed to consume within {after_s}s"
+                assert true_after(statement, after_s=after_s), msg
+
+
+@pytest.mark.parametrize(
+    "n_failures,consumer_cls_",
+    [
+        (2, _ConnectionLostConsumer_),
+        (2, _RecoverableErrorConsumer_),
+    ],
+)
+def test_consumer_should_reconnect_for_recoverable_error(
+    rabbit_mq: str,
+    n_failures: int,
+    consumer_cls_: Type[_TestConsumer_],
+    amqp_loggers,  # pylint: disable=unused-argument
+):
+    # Given
+    broker_url = rabbit_mq
+    queue = "test-queue"
+    exchange = "default-ex"
+    routing_key = "test"
+    test_consumer_cls = _consumer_factory(consumer_cls_, n_failures)
+    recover_from = (_RecoverableError, ConnectionLostError)
+    consumer = test_consumer_cls(
+        on_message=_do_nothing,
+        name="test-consumer",
+        exchange=exchange,
+        broker_url=broker_url,
+        queue=queue,
+        routing_key=routing_key,
+        max_connection_wait_s=0.1,
+        max_connection_attempts=5,
+        recover_from=recover_from,
+    )
+
+    with _shutdown_nowait(ThreadPoolExecutor()) as executor:
+        with consumer:
+            executor.submit(consumer.consume)
+            # When
+            with BlockingConnection(URLParameters(broker_url)) as connection:
+                with connection.channel() as channel:
+                    channel.basic_publish(
+                        exchange,
+                        routing_key,
+                        b"",
+                        BasicProperties(
+                            content_type="text/plain",
+                            delivery_mode=DeliveryMode.Transient,
+                        ),
+                    )
+
+                # Then
+                after_s = 1.0
+                statement = (
+                    lambda: consumer.consumed  # pylint: disable=unnecessary-lambda-assignment
+                )
+                msg = f"consumer failed to consume within {after_s}s"
+                assert true_after(statement, after_s=after_s), msg
+
+
+def test_consumer_should_not_reconnect_on_fatal_error(
+    rabbit_mq: str,
+    amqp_loggers,  # pylint: disable=unused-argument
+):
+    # Given
+    broker_url = rabbit_mq
+    queue = "test-queue"
+    exchange = "default-ex"
+    routing_key = "test"
+    test_consumer_cls = _consumer_factory(_FatalErrorConsumer_, 0)
+    consumer = test_consumer_cls(
+        on_message=_do_nothing,
+        name="test-consumer",
+        exchange=exchange,
+        broker_url=broker_url,
+        queue=queue,
+        routing_key=routing_key,
+        max_connection_wait_s=0.1,
+        max_connection_attempts=5,
+    )
+    with _shutdown_nowait(ThreadPoolExecutor()) as executor:
+        with consumer:
+            future_res = executor.submit(consumer.consume)
+
+            # When
+            with BlockingConnection(URLParameters(broker_url)) as connection:
+                with connection.channel() as channel:
+                    channel.basic_publish(
+                        exchange,
+                        routing_key,
+                        b"",
+                        BasicProperties(
+                            content_type="text/plain",
+                            delivery_mode=DeliveryMode.Transient,
+                        ),
+                    )
+
+                # Then
+                with pytest.raises(StreamLostError) as exc:
+                    future_res.result()
+                    assert exc.match(
+                        '_FatalError("this is too fatal i can\'t recover from this")'
+                    )
+
+
+def test_consumer_should_not_reconnect_too_many_times_when_inactive(rabbit_mq: str):
+    # Given
+    broker_url = rabbit_mq
+    queue = "test-queue"
+    exchange = "default-ex"
+    routing_key = "test"
+    n_failures = 10
+    max_connection_attempts = 1
+    inactive_after_s = 0  # Let's trigger the inactivity
+    test_consumer_cls = _consumer_factory(_RecoverableErrorConsumer_, n_failures)
+    recover_from = (_RecoverableError,)
+    consumer = test_consumer_cls(
+        on_message=_do_nothing,
+        name="test-consumer",
+        exchange=exchange,
+        broker_url=broker_url,
+        queue=queue,
+        routing_key=routing_key,
+        max_connection_wait_s=0.1,
+        max_connection_attempts=max_connection_attempts,
+        inactive_after_s=inactive_after_s,
+        recover_from=recover_from,
+    )
+
+    with _shutdown_nowait(ThreadPoolExecutor()) as executor:
+        with consumer:
+            future_res = executor.submit(consumer.consume)
+
+            # When
+            with BlockingConnection(URLParameters(broker_url)) as connection:
+                with connection.channel() as channel:
+                    channel.basic_publish(
+                        exchange,
+                        routing_key,
+                        b"",
+                        BasicProperties(
+                            content_type="text/plain",
+                            delivery_mode=DeliveryMode.Transient,
+                        ),
+                    )
+
+                    # Then
+                    with pytest.raises(_RecoverableError):
+                        future_res.result()
+
+
+def test_consumer_should_close_gracefully_on_sigint(rabbit_mq: str):
+    # Given
+    main_test_path = Path(__file__).parent / "consumer_main.py"
+    cmd = [sys.executable, main_test_path, rabbit_mq]
+
+    # Then
+    with Popen(cmd, stderr=PIPE, stdout=PIPE, text=True) as p:
+        # Wait for the consumer to be running
+        assert true_after(
+            lambda: any("starting consuming" in l for l in p.stderr), after_s=2.0
+        ), "Failed to start consumer"
+        # Kill it
+        p.send_signal(signal.SIGINT)
+        assert true_after(
+            lambda: any("shutting down gracefully" in l for l in p.stderr), after_s=2.0
+        ), "Failed to shutdown consumer gracefully"
+
+
+def test_consumer_should_close_immediately_on_sigterm(rabbit_mq: str):
+    # Given
+    main_test_path = Path(__file__).parent / "consumer_main.py"
+    cmd = [sys.executable, main_test_path, rabbit_mq]
+
+    # Then
+    with Popen(cmd, stderr=PIPE, stdout=PIPE, text=True) as p:
+        # Wait for the consumer to be running
+        assert true_after(
+            lambda: any("starting consuming" in l for l in p.stderr), after_s=2.0
+        ), "Failed to start consumer"
+        # Kill it
+        p.send_signal(signal.SIGTERM)
+        assert true_after(
+            lambda: any("shutting down the hard way" in l for l in p.stderr),
+            after_s=2.0,
+        ), "Failed to shutdown consumer immediately"

--- a/neo4j-app/neo4j_app/tests/icij_worker/test_publisher.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/test_publisher.py
@@ -95,7 +95,7 @@ async def test_publisher_should_reconnect_for_recoverable_error(
         assert success_i == n_disconnects
 
 
-def test_publisher_should_not_reconnect_from_non_recoverable_error(rabbit_mq: str):
+def test_publisher_should_not_reconnect_on_fatal_error(rabbit_mq: str):
     # Given
     broker_url = rabbit_mq
     queue = "test-queue"


### PR DESCRIPTION
# Before merging
- [ ] merge #42

# PR description

Implements a reconnecting AMPQ consumer which will later be used in the AMQP worker to consume messages.

The consumer was written using a [pika.SelectConnection](https://pika.readthedocs.io/en/stable/modules/adapters/select.html#pika.adapters.select_connection.SelectConnection).
The consumer has been written with the idea that it should be able to recover from a number of AMQP-related recoverable errors. Recovering from these errors will allow the worker to keep consuming task rather than exiting and having to relaunch it manually.


# Changes

## `datashare-extension-neo4j/neo4j-app`
### Added
- Added a `icij_worker.icij_worker.MessageConsumer` based on the [pika implementation](https://github.com/pika/pika/blob/main/examples/asyncio_consumer_example.py)
- The `MessageConsumer` wraps a `_MessageConsumer` and can recovers from a number of AMQP related errors which can be provided at initialization through the `recover_from` attribute. When such an error occur, the inner `_MessageConsumer` will stop and try to reconnect at most `max_connection_attempts` waiting before each reconnection. When the consumer is considered active, i.e, the last message was received recently (< `_inactive_after_s`), the attempt counter is not incremented. When the consumer is considered inactive, it will end up dying after `max_connection_attempts`.
- Added the `_MessageConsumer.consume`, starts an asynchronous IO loop in which the consumer will create a AMQP connection and a channel. When they are created it will declare an exchange and a queue from which it will consume (the operation is idempotent). Later the consumer will process incoming message with the `_MessageConsumer.on_message` method while. A custom processing function can be forwarded throught the `on_message` initialization attribute.
- The `_MessageConsumer` can be stopped, with the `stop` message which will try to cleanly close the IO loop
