### PR TITLE
feature: publish errors, events and results in the `MessagePublisher`

### DIFF
--- a/neo4j-app/neo4j_app/icij_worker/__init__.py
+++ b/neo4j-app/neo4j_app/icij_worker/__init__.py
@@ -1,1 +1,2 @@
+from .config import Exchange, Routing
 from .publisher import MessagePublisher

--- a/neo4j-app/neo4j_app/icij_worker/config.py
+++ b/neo4j-app/neo4j_app/icij_worker/config.py
@@ -1,0 +1,17 @@
+from pika.exchange_type import ExchangeType
+
+from neo4j_app.core.utils.pydantic import (
+    LowerCamelCaseModel,
+    NoEnumModel,
+)
+
+
+class Exchange(NoEnumModel, LowerCamelCaseModel):
+    name: str
+    type: ExchangeType
+
+
+class Routing(LowerCamelCaseModel):
+    exchange: Exchange
+    routing_key: str
+    default_queue: str

--- a/neo4j-app/neo4j_app/icij_worker/task.py
+++ b/neo4j-app/neo4j_app/icij_worker/task.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import traceback
+from enum import Enum, unique
+from typing import Any, Dict, Optional
+
+from neo4j_app.core.utils.pydantic import IgnoreExtraModel, LowerCamelCaseModel
+
+
+PROGRESS_HANDLER_ARG = "progress_handler"
+
+
+@unique
+class TaskStatus(str, Enum):
+    CREATED = "CREATED"
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    RETRY = "RETRY"
+    ERROR = "ERROR"
+    DONE = "DONE"
+    CANCELLED = "CANCELLED"
+
+
+class Task(LowerCamelCaseModel, IgnoreExtraModel):
+    id: str
+    type: str
+    status: TaskStatus
+    created_at: str
+    inputs: Dict[str, Any]
+
+
+class TaskEvent(LowerCamelCaseModel, IgnoreExtraModel):
+    task_id: str
+    status: Optional[TaskStatus] = None
+    progress: Optional[float] = None
+    error: Optional[str] = None
+    retries: Optional[int] = None
+
+
+class TaskResult(LowerCamelCaseModel, IgnoreExtraModel):
+    task_id: str
+    result: object
+
+
+class TaskError(LowerCamelCaseModel, IgnoreExtraModel):
+    # Follow the "problem detail" spec:
+    # https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-http-problem-00
+    task_id: str
+    title: str
+    detail: str
+
+    @classmethod
+    def from_exception(cls, exception: Exception, task_id: str) -> TaskError:
+        title = exception.__class__.__name__
+        trace_lines = traceback.format_exception(
+            None, value=exception, tb=exception.__traceback__
+        )
+        detail = f"{exception}\n{''.join(trace_lines)}"
+        return TaskError(task_id=task_id, title=title, detail=detail)

--- a/neo4j-app/neo4j_app/tests/icij_worker/test_publisher.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/test_publisher.py
@@ -1,14 +1,37 @@
-import pika
+from unittest.mock import MagicMock, call, patch
+
 import pytest
-from pika import DeliveryMode, URLParameters
+from pika import BasicProperties, BlockingConnection, DeliveryMode, URLParameters
 from pika.exceptions import (
     ConnectionOpenAborted,
     NackError,
     StreamLostError,
     UnroutableError,
 )
+from pika.exchange_type import ExchangeType
 
+from neo4j_app import icij_worker
+from neo4j_app.icij_worker import Exchange, Routing
 from neo4j_app.icij_worker.publisher import MessagePublisher
+from neo4j_app.icij_worker.task import TaskError, TaskEvent, TaskResult
+
+_EVENT_ROUTING = Routing(
+    exchange=Exchange(name="event-ex", type=ExchangeType.fanout),
+    routing_key="event",
+    default_queue="event-q",
+)
+
+_ERROR_ROUTING = Routing(
+    exchange=Exchange(name="error-ex", type=ExchangeType.topic),
+    routing_key="error",
+    default_queue="error-q",
+)
+
+_RESULT_ROUTING = Routing(
+    exchange=Exchange(name="result-ex", type=ExchangeType.topic),
+    routing_key="result",
+    default_queue="result-q",
+)
 
 
 class _TestablePublisher(MessagePublisher):
@@ -26,24 +49,30 @@ class _TestablePublisher(MessagePublisher):
 async def test_publisher_should_publish(rabbit_mq: str, mandatory: bool):
     # Given
     broker_url = rabbit_mq
-    queue = "test-queue"
+    exchange = _EVENT_ROUTING.exchange.name
+    queue = _EVENT_ROUTING.default_queue
+    routing_key = _EVENT_ROUTING.routing_key
+    message = "hello world"
     publisher = MessagePublisher(
         name="test-publisher",
-        exchange="default-ex",
         broker_url=broker_url,
-        queue=queue,
-        routing_key="test",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
     )
-    message = "hello world"
 
     # When
     with publisher.connect():
-        publisher.publish_message(
-            message.encode(), delivery_mode=DeliveryMode.Transient, mandatory=mandatory
+        publisher._publish_message(  # pylint: disable=protected-access
+            message.encode(),
+            exchange=exchange,
+            routing_key=routing_key,
+            delivery_mode=DeliveryMode.Transient,
+            mandatory=mandatory,
         )
 
     # Then
-    connection = pika.BlockingConnection(URLParameters(broker_url))
+    connection = BlockingConnection(URLParameters(broker_url))
     channel = connection.channel()
     _, _, body = channel.basic_get(queue, auto_ack=True)
     assert body.decode() == message
@@ -66,14 +95,13 @@ async def test_publisher_should_reconnect_for_recoverable_error(
 ):
     # Given
     broker_url = rabbit_mq
-    queue = "test-queue"
     recover_from = (ConnectionError, UnroutableError, NackError)
     publisher = _TestablePublisher(
         name="test-publisher",
-        exchange="default-ex",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
         broker_url=broker_url,
-        queue=queue,
-        routing_key="test",
         recover_from=recover_from,
     )
     max_attempt = 10
@@ -98,13 +126,12 @@ async def test_publisher_should_reconnect_for_recoverable_error(
 def test_publisher_should_not_reconnect_from_non_recoverable_error(rabbit_mq: str):
     # Given
     broker_url = rabbit_mq
-    queue = "test-queue"
     publisher = MessagePublisher(
         name="test-publisher",
-        exchange="default-ex",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
         broker_url=broker_url,
-        queue=queue,
-        routing_key="test",
     )
     max_attempt = 10
 
@@ -124,13 +151,12 @@ def test_publisher_should_not_reconnect_from_non_recoverable_error(rabbit_mq: st
 def test_publisher_should_not_reconnect_too_many_times(rabbit_mq: str):
     # Given
     broker_url = rabbit_mq
-    queue = "test-queue"
     publisher = MessagePublisher(
         name="test-publisher",
-        exchange="default-ex",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
         broker_url=broker_url,
-        queue=queue,
-        routing_key="test",
     )
     max_attempt = 2
 
@@ -142,3 +168,171 @@ def test_publisher_should_not_reconnect_too_many_times(rabbit_mq: str):
             ):
                 with attempt:
                     raise ConnectionOpenAborted()
+
+
+def test_publisher_should_create_and_bind_exchanges_and_queues():
+    # pylint: disable=protected-access
+    # Given
+    broker_url = "amqp://guest:guest@localhost:666/vhost"
+    mocked_connection = MagicMock()
+    mocked_channel = MagicMock()
+    mocked_connection.channel = MagicMock(return_value=mocked_channel)
+    publisher = MessagePublisher(
+        broker_url=broker_url,
+        name="test-publisher",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
+    )
+    with patch.object(
+        icij_worker.publisher, "BlockingConnection", new=mocked_connection
+    ):
+        # When
+        with publisher.connect():
+            # Then
+            exchange_declared = publisher._channel.exchange_declare
+            expected_exchange_calls = [
+                call(
+                    exchange="error-ex", exchange_type=ExchangeType.topic, durable=True
+                ),
+                call(
+                    exchange="event-ex", exchange_type=ExchangeType.fanout, durable=True
+                ),
+                call(
+                    exchange="result-ex", exchange_type=ExchangeType.topic, durable=True
+                ),
+            ]
+            assert exchange_declared.call_args_list == expected_exchange_calls
+            queue_declared = publisher._channel.queue_declare
+            expected_queue_calls = [
+                call("error-q", durable=True),
+                call("event-q", durable=True),
+                call("result-q", durable=True),
+            ]
+            assert queue_declared.call_args_list == expected_queue_calls
+            queue_bind = publisher._channel.queue_bind
+            expected_bind_calls = [
+                call(queue="error-q", exchange="error-ex", routing_key="error"),
+                call(queue="event-q", exchange="event-ex", routing_key="event"),
+                call(queue="result-q", exchange="result-ex", routing_key="result"),
+            ]
+            assert queue_bind.call_args_list == expected_bind_calls
+
+
+def test_publisher_publish_event():
+    # pylint: disable=protected-access
+    # Given
+    broker_url = "amqp://guest:guest@localhost:666/vhost"
+    mocked_connection = MagicMock()
+    mocked_channel = MagicMock()
+    mocked_connection.channel = MagicMock(return_value=mocked_channel)
+    publisher = MessagePublisher(
+        broker_url=broker_url,
+        name="test-publisher",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
+    )
+    event = TaskEvent(task_id="some_task", progress=50.0)
+    with patch.object(
+        icij_worker.publisher, "BlockingConnection", new=mocked_connection
+    ):
+        # When
+        with publisher.connect():
+            publisher.publish_task_event(
+                event,
+                delivery_mode=DeliveryMode.Persistent,
+                mandatory=True,
+            )
+            # Then
+            basic_publish = publisher._channel.basic_publish
+            serialized_event = b'{"task_id": "some_task", "status": null, \
+"progress": 50.0, "error": null, "retries": null}'
+            expected_call = call(
+                "event-ex",
+                "event",
+                serialized_event,
+                BasicProperties(delivery_mode=DeliveryMode.Persistent),
+                mandatory=True,
+            )
+            assert basic_publish.call_args_list == [expected_call]
+
+
+def test_publisher_publish_error():
+    # pylint: disable=protected-access
+    # Given
+    broker_url = "amqp://guest:guest@localhost:666/vhost"
+    mocked_connection = MagicMock()
+    mocked_channel = MagicMock()
+    mocked_connection.channel = MagicMock(return_value=mocked_channel)
+    publisher = MessagePublisher(
+        broker_url=broker_url,
+        name="test-publisher",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
+    )
+    task_id = "some_task_id"
+
+    with patch.object(
+        icij_worker.publisher, "BlockingConnection", new=mocked_connection
+    ):
+        # When
+        with publisher.connect():
+            e = ValueError("some error here")
+            task_error = None
+            try:
+                raise e
+            except ValueError as ve:
+                task_error = TaskError.from_exception(ve, task_id=task_id)
+            publisher.publish_task_error(task_error)
+
+            # Then
+            basic_publish = publisher._channel.basic_publish
+            serialized_error = f"{task_error.json()}".encode()
+            expected_call = call(
+                "error-ex",
+                "error",
+                serialized_error,
+                BasicProperties(delivery_mode=DeliveryMode.Persistent),
+                mandatory=True,
+            )
+            assert basic_publish.call_args_list == [expected_call]
+
+
+def test_publisher_publish_result():
+    # pylint: disable=protected-access
+    # Given
+    broker_url = "amqp://guest:guest@localhost:666/vhost"
+    mocked_connection = MagicMock()
+    mocked_channel = MagicMock()
+    mocked_connection.channel = MagicMock(return_value=mocked_channel)
+    publisher = MessagePublisher(
+        broker_url=broker_url,
+        name="test-publisher",
+        event_routing=_EVENT_ROUTING,
+        result_routing=_RESULT_ROUTING,
+        error_routing=_ERROR_ROUTING,
+    )
+    result = TaskResult(
+        task_id="some_task", result="some json serializable results here"
+    )
+
+    with patch.object(
+        icij_worker.publisher, "BlockingConnection", new=mocked_connection
+    ):
+        # When
+        with publisher.connect():
+            publisher.publish_task_result(result)
+
+            # Then
+            basic_publish = publisher._channel.basic_publish
+            serialized_result = f"{result.json()}".encode()
+            expected_call = call(
+                "result-ex",
+                "result",
+                serialized_result,
+                BasicProperties(delivery_mode=DeliveryMode.Persistent),
+                mandatory=True,
+            )
+            assert basic_publish.call_args_list == [expected_call]


### PR DESCRIPTION
# Before merging
- [ ] merge #42

# PR description

This PR wraps replaces the `MessagePublisher.publish_message` method with:
- `MessagePublisher.publish_task_event`
- `MessagePublisher.publish_task_error`
- `MessagePublisher.publish_task_result`

Each method published messages to a dedicated exchange which has a default queue bound to it using a routing key. By default the publisher don't published these different kind of messages to the same exchange. Indeed, the type of messages sent by each message don't share the same criticity. While error and results must not be lost, task updates events can be lost and triggered in a fire and forget manner. That why it's possible to configure one exchange for each method, leaving for instance the ability to use a `ExchangeType.fanout` for updates events, while using a `ExchangeType.topic` for errors and results. 

Similarly, errors and results will use [publisher confirms](https://www.rabbitmq.com/confirms.html#publisher-confirms) and `DeliveryMode.Persistent` while this choice is left to the user for task update events.


# Change

## `datashare-extension-neo4j/neo4j-app`
### Added
- Implemented the `icij_worker.Task` which represents a piece of work which must be done by a worker
- Created the `icij_worker.TaskStatus` enums which represents possible tasks states
- Implemented the `icij_worker.TaskEvent` class which is used to publish task related events: status update, progress update, error message, new retry
- Implemented the `icij_worker.TaskError` class which is used to publisher task errors. Contraty to error event which hold error message, the error provideds a detailed view of the task error. The `TaskError` partially follows the [`application/json+problem` spec](https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-http-problem-00)
- Added the `MessagePublisher.publish_task_event` method which broadcasts task updates event to a dedicated task exchange specified in the `event_routing: Routing` initialization attribute. The routing also provides a default queue which is bound to that exchange using a specified routing key.
- `MessagePublisher.publish_task_error` method which broadcasts task errors to a dedicated error exchange specified in the `error_routing: Routing` initialization attribute. The routing also provides a default queue which is bound to that exchange using a specified routing key.
- `MessagePublisher.publish_task_result` method which broadcasts task results to a dedicated error exchange specified in the `error_routing: Routing` initialization attribute. The routing also provides a default queue which is bound to that exchange using a specified routing key.

### Changed
- Replaced the `MessagePublisher.publish_message` with a `MessagePublisher._publish_message`