### PR TITLE
feature: implement AMQP `ICIJApp` and `Worker`

### DIFF
--- a/neo4j-app/neo4j_app/icij_worker/__init__.py
+++ b/neo4j-app/neo4j_app/icij_worker/__init__.py
@@ -1,1 +1,2 @@
+from .config import Exchange, Routing
 from .publisher import MessagePublisher

--- a/neo4j-app/neo4j_app/icij_worker/__init__.py
+++ b/neo4j-app/neo4j_app/icij_worker/__init__.py
@@ -1,2 +1,5 @@
+from .app import ICIJApp
 from .config import Exchange, Routing
+from .consumer import MessageConsumer
 from .publisher import MessagePublisher
+from .task import TaskError, TaskEvent, TaskResult, TaskStatus

--- a/neo4j-app/neo4j_app/icij_worker/app.py
+++ b/neo4j-app/neo4j_app/icij_worker/app.py
@@ -29,10 +29,13 @@ class ICIJApp:
 
     def task(
         self,
-        name: str,
+        name: Optional[str] = None,
         recover_from: Tuple[Type[Exception]] = tuple(),
         max_retries: Optional[int] = None,
     ) -> Callable:
+        if callable(name) and not recover_from and max_retries is None:
+            f = name
+            return functools.partial(self._register_task, name=f.__name__)(f)
         return functools.partial(
             self._register_task,
             name=name,
@@ -44,10 +47,12 @@ class ICIJApp:
         self,
         f: Callable,
         *,
-        name: str,
+        name: Optional[str] = None,
         recover_from: Tuple[Type[Exception]] = tuple(),
         max_retries: Optional[int] = None,
     ) -> Callable:
+        if name is None:
+            name = f.__name__
         registered = self._registry.get(name)
         if registered is not None:
             raise ValueError(f'A task "{name}" was already registered: {registered}')

--- a/neo4j-app/neo4j_app/icij_worker/config.py
+++ b/neo4j-app/neo4j_app/icij_worker/config.py
@@ -1,0 +1,17 @@
+from pika.exchange_type import ExchangeType
+
+from neo4j_app.core.utils.pydantic import (
+    LowerCamelCaseModel,
+    NoEnumModel,
+)
+
+
+class Exchange(NoEnumModel, LowerCamelCaseModel):
+    name: str
+    type: ExchangeType
+
+
+class Routing(LowerCamelCaseModel):
+    exchange: Exchange
+    routing_key: str
+    default_queue: str

--- a/neo4j-app/neo4j_app/icij_worker/consumer.py
+++ b/neo4j-app/neo4j_app/icij_worker/consumer.py
@@ -33,16 +33,16 @@ class _MessageConsumer(LogWithNameMixin):
     _logger = logger
 
     def __init__(
-        self,
-        *,
-        on_message: Callable,
-        name: str,
-        exchange: str,
-        broker_url: str,
-        queue: str,
-        routing_key: str,
-        app_id: Optional[str] = None,
-        recover_from: Tuple[Type[Exception], ...] = tuple(),
+            self,
+            *,
+            on_message: Callable,
+            name: str,
+            exchange: str,
+            broker_url: str,
+            queue: str,
+            routing_key: str,
+            app_id: Optional[str] = None,
+            recover_from: Tuple[Type[Exception], ...] = tuple(),
     ):
         self._on_message = on_message
 
@@ -108,259 +108,287 @@ class _MessageConsumer(LogWithNameMixin):
             raise ValueError(msg)
         return self._channel_
 
-    @cached_property
-    def _exception_namespace(self) -> Dict:
-        ns = dict(globals())
-        ns.update({exc_type.__name__: exc_type for exc_type in self._recover_from})
-        return ns
+@cached_property
+def _exception_namespace(self) -> Dict:
+    ns = dict(globals())
+    ns.update({exc_type.__name__: exc_type for exc_type in self._recover_from})
+    return ns
 
-    def connect(self):
-        self._log(logging.DEBUG, "connecting to %s", self._broker_url)
-        # TODO: heartbeat ? blocked connection timeout ?
-        self._connection_ = SelectConnection(
-            parameters=pika.URLParameters(self._broker_url),
-            on_open_callback=self._on_connection_open,
-            on_open_error_callback=self._on_connection_open_error,
-            on_close_callback=self._on_connection_closed,
-        )
 
-    def on_message(
+def connect(self):
+    self._log(logging.DEBUG, "connecting to %s", self._broker_url)
+    # TODO: heartbeat ? blocked connection timeout ?
+    self._connection_ = SelectConnection(
+        parameters=pika.URLParameters(self._broker_url),
+        on_open_callback=self._on_connection_open,
+        on_open_error_callback=self._on_connection_open_error,
+        on_close_callback=self._on_connection_closed,
+    )
+
+
+def on_message(
         self,
         _unused_channel: Channel,  # pylint: disable=invalid-name
         basic_deliver: Basic.Deliver,
         _properties: BasicProperties,  # pylint: disable=invalid-name
         body: bytes,
-    ):
-        self._last_message_received_at = time.monotonic()
-        msg = "received message # %s"
-        if self._app_id is not None:
-            msg = f"{msg} from {self._app_id}"
-        self._log(logging.DEBUG, msg, basic_deliver.delivery_tag)
-        self._on_message(body)
-        self._acknowledge_message(basic_deliver.delivery_tag)
+):
+    self._last_message_received_at = time.monotonic()
+    msg = "received message # %s"
+    if self._app_id is not None:
+        msg = f"{msg} from {self._app_id}"
+    self._log(logging.DEBUG, msg, basic_deliver.delivery_tag)
+    self._on_message(body)
+    self._acknowledge_message(basic_deliver.delivery_tag)
 
-    def consume(self):
-        self.connect()
-        self._connection.ioloop.start()
 
-    def stop(self):
-        if not self._closing:
-            self._closing = True
-            self._log(logging.INFO, "stopping...")
-            if self._consuming:
-                # The IOLoop is started again because this method is invoked  when
-                # CTRL-C is pressed raising a KeyboardInterrupt exception. This
-                # exception stops the IOLoop which needs to be running for pika to
-                # communicate with RabbitMQ. All the commands issued prior to
-                # starting the IOLoop will be buffered but not processed.
-                self._stop_consuming()
-                # Calling start will fail if the loop is already running
-                try:
-                    self._connection.ioloop.start()
-                # not robust, but sadly pika does not provide a more catchable
-                # exception type...
-                except RuntimeError as e:
-                    if _IOLOOP_ALREADY_RUNNING_MSG not in str(e):
-                        raise e
-            else:
-                if self._connection_ is not None:
-                    self._connection.ioloop.stop()
-            self._log(logging.INFO, "stopped !")
+def consume(self):
+    self.connect()
+    self._connection.ioloop.start()
 
-    def _trigger_reconnect(self):
-        self._should_reconnect = True
 
-    def _stop_consuming(self):
-        if self._channel:
-            self._log(logging.DEBUG, "sending a Basic.Cancel RPC command to RabbitMQ")
-            self._channel.basic_cancel(self.consumer_tag, self._on_cancelok)
-
-    def _acknowledge_message(self, delivery_tag: int):
-        self._log(logging.DEBUG, "acknowledging message %s", delivery_tag)
-        self._channel.basic_ack(delivery_tag)
-
-    def _close_connection(self):
-        self._consuming = False
-        if self._connection.is_closing or self._connection.is_closed:
-            self._log(logging.DEBUG, "connection is closing or already closed")
+def stop(self):
+    if not self._closing:
+        self._closing = True
+        self._log(logging.INFO, "stopping...")
+        if self._consuming:
+            # The IOLoop is started again because this method is invoked  when
+            # CTRL-C is pressed raising a KeyboardInterrupt exception. This
+            # exception stops the IOLoop which needs to be running for pika to
+            # communicate with RabbitMQ. All the commands issued prior to
+            # starting the IOLoop will be buffered but not processed.
+            self._stop_consuming()
+            # Calling start will fail if the loop is already running
+            try:
+                self._connection.ioloop.start()
+            # not robust, but sadly pika does not provide a more catchable
+            # exception type...
+            except RuntimeError as e:
+                if _IOLOOP_ALREADY_RUNNING_MSG not in str(e):
+                    raise e
         else:
-            self._log(logging.DEBUG, "closing connection")
-            self._connection.close()
+            if self._connection_ is not None:
+                self._connection.ioloop.stop()
+        self._log(logging.INFO, "stopped !")
 
-    def _on_connection_open(self, _unused_connection: BaseConnection):
-        # pylint: disable=invalid-name
-        self._log(logging.DEBUG, "connection opened !")
-        self._open_channel()
 
-    def _on_connection_open_error(
+def _trigger_reconnect(self):
+    self._should_reconnect = True
+
+
+def _stop_consuming(self):
+    if self._channel:
+        self._log(logging.DEBUG, "sending a Basic.Cancel RPC command to RabbitMQ")
+        self._channel.basic_cancel(self.consumer_tag, self._on_cancelok)
+
+
+def _acknowledge_message(self, delivery_tag: int):
+    self._log(logging.DEBUG, "acknowledging message %s", delivery_tag)
+    self._channel.basic_ack(delivery_tag)
+
+
+def _close_connection(self):
+    self._consuming = False
+    if self._connection.is_closing or self._connection.is_closed:
+        self._log(logging.DEBUG, "connection is closing or already closed")
+    else:
+        self._log(logging.DEBUG, "closing connection")
+        self._connection.close()
+
+
+def _on_connection_open(self, _unused_connection: BaseConnection):
+    # pylint: disable=invalid-name
+    self._log(logging.DEBUG, "connection opened !")
+    self._open_channel()
+
+
+def _on_connection_open_error(
         self, _unused_connection: BaseConnection, err: Exception
-    ):
-        # pylint: disable=invalid-name
-        self._parse_error(err)
-        if isinstance(self._error, StreamLostError):
-            self._log(
-                logging.WARNING, "failed to parse stream lost internal error: %s", err
-            )
-        self._log(logging.ERROR, "connection open failed: %s", self._error)
+):
+    # pylint: disable=invalid-name
+    self._parse_error(err)
+    if isinstance(self._error, StreamLostError):
+        self._log(
+            logging.WARNING, "failed to parse stream lost internal error: %s", err
+        )
+    self._log(logging.ERROR, "connection open failed: %s", self._error)
+    if isinstance(self._error, self._recover_from):
+        self._log(logging.ERROR, "triggering reconnection !")
+        self._trigger_reconnect()
+    self.stop()
+
+
+def _on_connection_closed(
+        self, _unused_connection: BaseConnection, reason: Exception
+):
+    # pylint: disable=invalid-name
+    self._parse_error(reason)
+    self._channel_ = None
+    if self._closing:  # The connection was closed on purpose
+        self._connection.ioloop.stop()
+    else:
+        self._log(logging.ERROR, "connection was accidentally closed: %s", reason)
         if isinstance(self._error, self._recover_from):
             self._log(logging.ERROR, "triggering reconnection !")
             self._trigger_reconnect()
         self.stop()
 
-    def _on_connection_closed(
-        self, _unused_connection: BaseConnection, reason: Exception
-    ):
-        # pylint: disable=invalid-name
-        self._parse_error(reason)
-        self._channel_ = None
-        if self._closing:  # The connection was closed on purpose
-            self._connection.ioloop.stop()
-        else:
-            self._log(logging.ERROR, "connection was accidentally closed: %s", reason)
-            if isinstance(self._error, self._recover_from):
-                self._log(logging.ERROR, "triggering reconnection !")
-                self._trigger_reconnect()
-            self.stop()
 
-    def _open_channel(self):
-        self._log(logging.DEBUG, "creating a new channel")
-        self._connection.channel(on_open_callback=self._on_channel_open)
+def _open_channel(self):
+    self._log(logging.DEBUG, "creating a new channel")
+    self._connection.channel(on_open_callback=self._on_channel_open)
 
-    def _on_channel_open(self, channel: Channel):
-        self._log(logging.DEBUG, "channel opened !")
-        self._channel_ = channel
-        self._add_on_channel_close_callback()
-        self._setup_exchange()
 
-    def _add_on_channel_close_callback(self):
-        self._channel.add_on_close_callback(self._on_channel_closed)
+def _on_channel_open(self, channel: Channel):
+    self._log(logging.DEBUG, "channel opened !")
+    self._channel_ = channel
+    self._add_on_channel_close_callback()
+    self._setup_exchange()
 
-    def _on_channel_closed(self, channel: Channel, reason: Exception):
-        self._log(
-            logging.WARNING, "channel %s was closed: %s", channel.channel_number, reason
-        )
-        self._close_connection()
 
-    def _setup_exchange(self):
-        self._log(logging.DEBUG, "declaring exchange: %s", self._exchange)
-        self._channel.exchange_declare(
-            exchange=self._exchange,
-            exchange_type=self._EXCHANGE_TYPE,
-            callback=self._on_exchange_declareok,
-            durable=True,
-        )
+def _add_on_channel_close_callback(self):
+    self._channel.add_on_close_callback(self._on_channel_closed)
 
-    def _on_exchange_declareok(self, _unused_frame: Method):
-        # pylint: disable=invalid-name
-        self._log(logging.DEBUG, "exchange %s declared", self._exchange)
-        self._setup_queue()
 
-    def _setup_queue(self):
-        self._log(logging.DEBUG, "declaring queue %s", self._queue)
-        self._channel.queue_declare(
-            queue=self._queue, callback=self._on_queue_declareok, durable=True
-        )
+def _on_channel_closed(self, channel: Channel, reason: Exception):
+    self._log(
+        logging.WARNING, "channel %s was closed: %s", channel.channel_number, reason
+    )
+    self._close_connection()
 
-    def _on_queue_declareok(self, _unused_frame: Method):
-        # pylint: disable=invalid-name
-        self._log(
-            logging.INFO,
-            "binding %s to %s with %s",
-            self._exchange,
-            self._queue,
-            self._routing_key,
-        )
-        self._channel.queue_bind(
-            self._queue,
-            self._exchange,
-            routing_key=self._routing_key,
-            callback=self._on_bindok,
-        )
 
-    def _on_bindok(self, _unused_frame: Method):
-        # pylint: disable=invalid-name
-        self._log(logging.DEBUG, "queue %s bound", self._queue)
-        self._set_qos()
+def _setup_exchange(self):
+    self._log(logging.DEBUG, "declaring exchange: %s", self._exchange)
+    self._channel.exchange_declare(
+        exchange=self._exchange,
+        exchange_type=self._EXCHANGE_TYPE,
+        callback=self._on_exchange_declareok,
+        durable=True,
+    )
 
-    def _set_qos(self):
-        self._channel.basic_qos(
-            prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok
-        )
 
-    def _on_basic_qos_ok(self, _unused_frame: Method):
-        # pylint: disable=invalid-name
-        self._log(logging.DEBUG, "QOS set to: %d", self._prefetch_count)
-        self._start_consuming()
+def _on_exchange_declareok(self, _unused_frame: Method):
+    # pylint: disable=invalid-name
+    self._log(logging.DEBUG, "exchange %s declared", self._exchange)
+    self._setup_queue()
 
-    def _start_consuming(self):
-        self._log(logging.INFO, "starting consuming...")
-        self._add_on_cancel_callback()
-        self._consumer_tag = self._channel.basic_consume(
-            self._queue, self.on_message, consumer_tag=self.consumer_tag
-        )
-        self._consuming = True
 
-    def _add_on_cancel_callback(self):
-        self._log(logging.DEBUG, "adding consumer cancellation callback")
-        self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
+def _setup_queue(self):
+    self._log(logging.DEBUG, "declaring queue %s", self._queue)
+    self._channel.queue_declare(
+        queue=self._queue, callback=self._on_queue_declareok, durable=True
+    )
 
-    def _on_consumer_cancelled(self, method_frame: Method):
-        # pylint: disable=invalid-name
-        self._log(
-            logging.ERROR,
-            "consumer was cancelled remotely, shutting down: %r",
-            method_frame,
-        )
-        if self._channel:
-            self._channel.close()
-        raise KeyboardInterrupt()
 
-    def _on_cancelok(self, _unused_frame: Method):
-        # pylint: disable=invalid-name
-        self._consuming = False
-        self._log(
-            logging.INFO,
-            "RabbitMQ acknowledged the cancellation of the consumer",
-        )
-        self._close_channel()
-        self._log(logging.INFO, "exiting consumer execution after cancellation")
+def _on_queue_declareok(self, _unused_frame: Method):
+    # pylint: disable=invalid-name
+    self._log(
+        logging.INFO,
+        "binding %s to %s with %s",
+        self._exchange,
+        self._queue,
+        self._routing_key,
+    )
+    self._channel.queue_bind(
+        self._queue,
+        self._exchange,
+        routing_key=self._routing_key,
+        callback=self._on_bindok,
+    )
 
-    def _close_channel(self):
-        self._log(logging.DEBUG, "closing the channel")
+
+def _on_bindok(self, _unused_frame: Method):
+    # pylint: disable=invalid-name
+    self._log(logging.DEBUG, "queue %s bound", self._queue)
+    self._set_qos()
+
+
+def _set_qos(self):
+    self._channel.basic_qos(
+        prefetch_count=self._prefetch_count, callback=self._on_basic_qos_ok
+    )
+
+
+def _on_basic_qos_ok(self, _unused_frame: Method):
+    # pylint: disable=invalid-name
+    self._log(logging.DEBUG, "QOS set to: %d", self._prefetch_count)
+    self._start_consuming()
+
+
+def _start_consuming(self):
+    self._log(logging.INFO, "starting consuming...")
+    self._add_on_cancel_callback()
+    self._consumer_tag = self._channel.basic_consume(
+        self._queue, self.on_message, consumer_tag=self.consumer_tag
+    )
+    self._consuming = True
+
+
+def _add_on_cancel_callback(self):
+    self._log(logging.DEBUG, "adding consumer cancellation callback")
+    self._channel.add_on_cancel_callback(self._on_consumer_cancelled)
+
+
+def _on_consumer_cancelled(self, method_frame: Method):
+    # pylint: disable=invalid-name
+    self._log(
+        logging.ERROR,
+        "consumer was cancelled remotely, shutting down: %r",
+        method_frame,
+    )
+    if self._channel:
         self._channel.close()
+    raise KeyboardInterrupt()
 
-    def _parse_error(self, error: Exception):
-        if isinstance(error, StreamLostError):
-            self._error = parse_stream_lost_error(
-                error, namespace=self._exception_namespace
+
+def _on_cancelok(self, _unused_frame: Method):
+    # pylint: disable=invalid-name
+    self._consuming = False
+    self._log(
+        logging.INFO,
+        "RabbitMQ acknowledged the cancellation of the consumer",
+    )
+    self._close_channel()
+    self._log(logging.INFO, "exiting consumer execution after cancellation")
+
+
+def _close_channel(self):
+    self._log(logging.DEBUG, "closing the channel")
+    self._channel.close()
+
+
+def _parse_error(self, error: Exception):
+    if isinstance(error, StreamLostError):
+        self._error = parse_stream_lost_error(
+            error, namespace=self._exception_namespace
+        )
+        if isinstance(self._error, StreamLostError):
+            self._log(
+                logging.WARNING,
+                "failed to parse internal stream lost error %s",
+                error,
             )
-            if isinstance(self._error, StreamLostError):
-                self._log(
-                    logging.WARNING,
-                    "failed to parse internal stream lost error %s",
-                    error,
-                )
-        else:
-            self._error = error
+    else:
+        self._error = error
 
 
 class MessageConsumer(LogWithNameMixin):
     _logger = logger
 
     def __init__(
-        self,
-        *,
-        on_message: Callable,
-        name: str,
-        exchange: str,
-        broker_url: str,
-        queue: str,
-        routing_key: str,
-        app_id: Optional[str] = None,
-        recover_from: Tuple[Type[Exception], ...] = tuple(),
-        max_connection_wait_s: float = 60.0,
-        max_connection_attempts: int = 5,
-        inactive_after_s: float = 60 * 60,
+            self,
+            *,
+            on_message: Callable,
+            name: str,
+            exchange: str,
+            broker_url: str,
+            queue: str,
+            routing_key: str,
+            app_id: Optional[str] = None,
+            recover_from: Tuple[Type[Exception], ...] = tuple(),
+            max_connection_wait_s: float = 60.0,
+            max_connection_attempts: int = 5,
+            inactive_after_s: float = 60 * 60,
     ):
         self._on_message = on_message
         self._name = name
@@ -482,12 +510,12 @@ class MessageConsumer(LogWithNameMixin):
         return max(0, min(result, self._max_wait_s))
 
     def _signal_handler(
-        self,
-        signal_name: str,
-        _,
-        __,  # pylint: disable=invalid-name
-        *,
-        graceful: bool,
+            self,
+            signal_name: str,
+            _,
+            __,  # pylint: disable=invalid-name
+            *,
+            graceful: bool,
     ):
         self._log(logging.ERROR, "received %s", signal_name)
         self._stop_gracefully = graceful

--- a/neo4j-app/neo4j_app/icij_worker/exceptions.py
+++ b/neo4j-app/neo4j_app/icij_worker/exceptions.py
@@ -1,4 +1,5 @@
 import abc
+from typing import Sequence
 
 
 class ICIJWorkerError(metaclass=abc.ABCMeta):
@@ -9,5 +10,22 @@ class MaxReconnectionExceeded(ICIJWorkerError, ConnectionError):
     ...
 
 
-class ConnectionLostError(ConnectionError):
+class MaxRetriesExceeded(ICIJWorkerError, RuntimeError):
     ...
+
+
+class ConnectionLostError(ICIJWorkerError, ConnectionError):
+    ...
+
+
+class InvalidTaskBody(ICIJWorkerError, ValueError):
+    ...
+
+
+class UnregisteredTask(ICIJWorkerError, ValueError):
+    def __init__(self, task_name: str, available_tasks: Sequence[str], *args, **kwargs):
+        msg = (
+            f'UnregisteredTask task "{task_name}", available tasks: {available_tasks}. '
+            f"Task must be registered using the @task decorator."
+        )
+        super().__init__(msg, *args, **kwargs)

--- a/neo4j-app/neo4j_app/icij_worker/task.py
+++ b/neo4j-app/neo4j_app/icij_worker/task.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import traceback
+from enum import Enum, unique
+from typing import Any, Dict, Optional
+
+from neo4j_app.core.utils.pydantic import IgnoreExtraModel, LowerCamelCaseModel
+
+
+PROGRESS_HANDLER_ARG = "progress_handler"
+
+
+@unique
+class TaskStatus(str, Enum):
+    CREATED = "CREATED"
+    QUEUED = "QUEUED"
+    RUNNING = "RUNNING"
+    RETRY = "RETRY"
+    ERROR = "ERROR"
+    DONE = "DONE"
+    CANCELLED = "CANCELLED"
+
+
+class Task(LowerCamelCaseModel, IgnoreExtraModel):
+    id: str
+    type: str
+    status: TaskStatus
+    created_at: str
+    inputs: Dict[str, Any]
+
+
+class TaskEvent(LowerCamelCaseModel, IgnoreExtraModel):
+    task_id: str
+    status: Optional[TaskStatus] = None
+    progress: Optional[float] = None
+    error: Optional[str] = None
+    retries: Optional[int] = None
+
+
+class TaskResult(LowerCamelCaseModel, IgnoreExtraModel):
+    task_id: str
+    result: object
+
+
+class TaskError(LowerCamelCaseModel, IgnoreExtraModel):
+    # Follow the "problem detail" spec:
+    # https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-http-problem-00
+    task_id: str
+    title: str
+    detail: str
+
+    @classmethod
+    def from_exception(cls, exception: Exception, task_id: str) -> TaskError:
+        title = exception.__class__.__name__
+        trace_lines = traceback.format_exception(
+            None, value=exception, tb=exception.__traceback__
+        )
+        detail = f"{exception}\n{''.join(trace_lines)}"
+        return TaskError(task_id=task_id, title=title, detail=detail)

--- a/neo4j-app/neo4j_app/icij_worker/task.py
+++ b/neo4j-app/neo4j_app/icij_worker/task.py
@@ -4,14 +4,19 @@ import traceback
 from enum import Enum, unique
 from typing import Any, Dict, Optional
 
-from neo4j_app.core.utils.pydantic import IgnoreExtraModel, LowerCamelCaseModel
+from pydantic import Field
 
+from neo4j_app.core.utils.pydantic import (
+    IgnoreExtraModel,
+    LowerCamelCaseModel,
+    NoEnumModel,
+)
 
 PROGRESS_HANDLER_ARG = "progress_handler"
 
 
 @unique
-class TaskStatus(str, Enum):
+class TaskStatus(Enum):
     CREATED = "CREATED"
     QUEUED = "QUEUED"
     RUNNING = "RUNNING"
@@ -21,15 +26,15 @@ class TaskStatus(str, Enum):
     CANCELLED = "CANCELLED"
 
 
-class Task(LowerCamelCaseModel, IgnoreExtraModel):
+class Task(NoEnumModel, LowerCamelCaseModel, IgnoreExtraModel):
     id: str
     type: str
     status: TaskStatus
     created_at: str
-    inputs: Dict[str, Any]
+    inputs: Dict[str, Any] = Field(default_factory=dict)
 
 
-class TaskEvent(LowerCamelCaseModel, IgnoreExtraModel):
+class TaskEvent(NoEnumModel, LowerCamelCaseModel, IgnoreExtraModel):
     task_id: str
     status: Optional[TaskStatus] = None
     progress: Optional[float] = None

--- a/neo4j-app/neo4j_app/icij_worker/typing.py
+++ b/neo4j-app/neo4j_app/icij_worker/typing.py
@@ -1,0 +1,16 @@
+from typing import Callable, Protocol
+
+from pika.spec import Basic, BasicProperties
+
+ProgressHandler = Callable[[float], None]
+
+
+class OnMessage(Protocol):
+    def __call__(
+        self,
+        consumer,
+        basic_deliver: Basic.Deliver,
+        properties: BasicProperties,
+        body: bytes,
+    ):
+        ...

--- a/neo4j-app/neo4j_app/icij_worker/typing.py
+++ b/neo4j-app/neo4j_app/icij_worker/typing.py
@@ -14,3 +14,14 @@ class OnMessage(Protocol):
         body: bytes,
     ):
         ...
+
+
+class ConsumerProtocol(Protocol):
+    def acknowledge_message(self, delivery_tag: int):
+        ...
+
+    def reject_message(self, delivery_tag: int, requeue: bool):
+        ...
+
+    def log(self, level: int, *args, **kwargs):
+        ...

--- a/neo4j-app/neo4j_app/icij_worker/worker.py
+++ b/neo4j-app/neo4j_app/icij_worker/worker.py
@@ -1,0 +1,182 @@
+import functools
+import logging
+import traceback
+from inspect import signature
+from typing import Callable, Optional, Protocol, Tuple, Type
+
+from pika.spec import Basic, BasicProperties
+from pydantic import ValidationError, parse_raw_as
+
+from neo4j_app.icij_worker import MessagePublisher
+from neo4j_app.icij_worker.app import ICIJApp, RegisteredTask
+from neo4j_app.icij_worker.exceptions import (
+    InvalidTaskBody,
+    MaxRetriesExceeded,
+    UnregisteredTask,
+)
+from neo4j_app.icij_worker.task import (
+    PROGRESS_HANDLER_ARG,
+    Task,
+    TaskError,
+    TaskEvent,
+    TaskResult,
+    TaskStatus,
+)
+
+
+class TaskConsumer(Protocol):
+    def acknowledge_message(self, delivery_tag: int):
+        ...
+
+    def reject_message(self, delivery_tag: int, requeue: bool):
+        ...
+
+    def log(self, level: int, *args, **kwargs):
+        ...
+
+
+def task_wrapper(
+    basic_deliver: Basic.Deliver,
+    properties: BasicProperties,
+    body: bytes,
+    *,
+    consumer: TaskConsumer,
+    publisher: MessagePublisher,
+    app: ICIJApp,
+):
+    task = _parse_task_body(body)
+    try:
+        task_fn, recoverable_errors = _parse_task(app, publisher, task)
+        _check_retries(app, task, properties, consumer)
+        try:
+            task_res = task_fn(**task.inputs)
+        except recoverable_errors as e:
+            consumer.log(
+                logging.ERROR, "%s(id=%s) recovering from: %s", task.type, task.id, e
+            )
+            # TODO: handle retry here...
+            event = TaskEvent(
+                task_id=task.id, error=_format_error(e), status=TaskStatus.RETRY
+            )
+            publisher.publish_task_event(event, mandatory=False)
+            # TODO: for now we requeue the task to its original queue. When retries will
+            #  be implemented, we'll probably have to put the message in the DLX using
+            #  requeue = False
+            consumer.reject_message(
+                delivery_tag=basic_deliver.delivery_tag, requeue=True
+            )
+            return
+        consumer.log(
+            logging.INFO, "publishing results for %s(id=%s)", task.type, task.id
+        )
+        result = TaskResult(task_id=task.id, result=task_res)
+        publisher.publish_task_result(result)
+        consumer.log(
+            logging.INFO, "marking %s(id=%s) as %s", task.type, task.id, TaskStatus.DONE
+        )
+        event = TaskEvent(
+            task_id=task.id, status=TaskStatus.DONE, progress=100, error=None
+        )
+        publisher.publish_task_event(event, mandatory=False)
+        consumer.log(logging.INFO, "task %s successful !", task.id)
+    except MaxRetriesExceeded as e:
+        consumer.log(logging.ERROR, e)
+        event = TaskEvent(
+            task_id=task.id, error=_format_error(e), status=TaskStatus.ERROR
+        )
+        publisher.publish_task_event(event, mandatory=False)
+        publisher.publish_task_error(TaskError.from_exception(e, task_id=task.id))
+        # Remove message from queue
+        consumer.acknowledge_message(delivery_tag=basic_deliver.delivery_tag)
+        consumer.log(
+            logging.ERROR, "%s(id=%s) definitively rejected", task.type, task.id
+        )
+        # Acknowledgement left to the outer scope
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        consumer.log(logging.ERROR, "task %s(id=%s), fatal error: %s", task.type, e)
+        event = TaskEvent(
+            task_id=task.id, error=_format_error(e), status=TaskStatus.ERROR
+        )
+        publisher.publish_task_event(event, mandatory=False)
+        publisher.publish_task_error(TaskError.from_exception(e, task_id=task.id))
+        consumer.reject_message(delivery_tag=basic_deliver.delivery_tag, requeue=False)
+        consumer.log(
+            logging.INFO, "%s(id=%s) definitively rejected", task.type, task.id
+        )
+    # Acknowledgement left to the outer scope
+
+
+def _parse_task(
+    app: ICIJApp, publisher: MessagePublisher, task: Task
+) -> Tuple[Callable, Tuple[Type[Exception], ...]]:
+    registered = _retrieve_registered_task(task, app)
+    recoverable = registered.recover_from
+    task_fn = registered.task
+    supports_progress = any(
+        param.name == PROGRESS_HANDLER_ARG
+        for param in signature(task_fn).parameters.values()
+    )
+    if supports_progress:
+        publish_progress = functools.partial(
+            _publish_progress,
+            functools.partial(publisher.publish_task_event, mandatory=False),
+            task_id=task.id,
+        )
+        task_fn = functools.partial(task_fn, progress_handler=publish_progress)
+    return task_fn, recoverable
+
+
+def _parse_task_body(body: bytes) -> Task:
+    try:
+        task = parse_raw_as(Task, body)
+    except ValidationError as e:
+        displayed_body = body[:1000]
+        error = InvalidTaskBody(f"Invalid task body {displayed_body}")
+        raise error from e
+    return task
+
+
+def _retrieve_registered_task(
+    task: Task,
+    app: ICIJApp,
+) -> RegisteredTask:
+    registered = app.registry.get(task.type)
+    if registered is None:
+        available_tasks = list(app.registry)
+        raise UnregisteredTask(task.type, available_tasks)
+    return registered
+
+
+def _publish_progress(
+    publish_task_event: Callable[[TaskEvent], None], progress: float, task_id: str
+):
+    updated = TaskEvent(progress=progress, task_id=task_id)
+    publish_task_event(updated)
+
+
+def _parse_retries(properties: BasicProperties) -> Optional[int]:
+    # pylint: disable=unused-argument
+    return None
+
+
+def _check_retries(
+    app: ICIJApp, task: Task, properties: BasicProperties, consumer: TaskConsumer
+):
+    # TODO: here we're retrying endlessly, in the future we should parse the message
+    #  header and raise a MaxRetriesExceeded when relevant
+    max_retries = app.registry[task.type].max_retries
+    retries = _parse_retries(properties)  # pylint: disable=assignment-from-none
+    consumer.log(
+        logging.INFO, "%s(id=%s): try %s/%s", task.type, task.id, retries, max_retries
+    )
+    if retries is not None and retries > max_retries:
+        raise MaxRetriesExceeded(
+            f"{task.type}(id={task.id}): max retries exceeded > {max_retries}"
+        )
+
+
+def _format_error(error: Exception) -> str:
+    formatted = "".join(
+        traceback.format_exception(None, value=error, tb=error.__traceback__)
+    )
+    return formatted

--- a/neo4j-app/neo4j_app/icij_worker/worker.py
+++ b/neo4j-app/neo4j_app/icij_worker/worker.py
@@ -2,7 +2,7 @@ import functools
 import logging
 import traceback
 from inspect import signature
-from typing import Callable, Optional, Protocol, Tuple, Type
+from typing import Callable, Optional, Tuple, Type
 
 from pika.spec import Basic, BasicProperties
 from pydantic import ValidationError, parse_raw_as
@@ -22,17 +22,7 @@ from neo4j_app.icij_worker.task import (
     TaskResult,
     TaskStatus,
 )
-
-
-class TaskConsumer(Protocol):
-    def acknowledge_message(self, delivery_tag: int):
-        ...
-
-    def reject_message(self, delivery_tag: int, requeue: bool):
-        ...
-
-    def log(self, level: int, *args, **kwargs):
-        ...
+from neo4j_app.icij_worker.typing import ConsumerProtocol
 
 
 def task_wrapper(
@@ -40,7 +30,7 @@ def task_wrapper(
     properties: BasicProperties,
     body: bytes,
     *,
-    consumer: TaskConsumer,
+    consumer: ConsumerProtocol,
     publisher: MessagePublisher,
     app: ICIJApp,
 ):
@@ -160,7 +150,7 @@ def _parse_retries(properties: BasicProperties) -> Optional[int]:
 
 
 def _check_retries(
-    app: ICIJApp, task: Task, properties: BasicProperties, consumer: TaskConsumer
+    app: ICIJApp, task: Task, properties: BasicProperties, consumer: ConsumerProtocol
 ):
     # TODO: here we're retrying endlessly, in the future we should parse the message
     #  header and raise a MaxRetriesExceeded when relevant

--- a/neo4j-app/neo4j_app/tests/icij_worker/conftest.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/conftest.py
@@ -63,7 +63,7 @@ def test_management_url(url: str) -> str:
 
 async def _wipe_rabbit_mq():
     async with aiohttp.ClientSession(
-        raise_for_status=True, auth=_DEFAULT_AUTH
+            raise_for_status=True, auth=_DEFAULT_AUTH
     ) as session:
         await _delete_all_connections(session)
         tasks = [_delete_all_exchanges(session), _delete_all_queues(session)]
@@ -114,10 +114,10 @@ async def _delete_queue(session: aiohttp.ClientSession, name: str):
 
 
 def true_after(
-    state_statement: Callable,
-    *,
-    after_s: float,
-    sleep_s: float = 0.01,
+        state_statement: Callable,
+        *,
+        after_s: float,
+        sleep_s: float = 0.01,
 ) -> bool:
     start = monotonic()
     while "waiting for the statement to be True":

--- a/neo4j-app/neo4j_app/tests/icij_worker/conftest.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/conftest.py
@@ -208,10 +208,8 @@ def consumer_factory(consumer_cls: Type[TestConsumer__], n_failures: int) -> Typ
             return consumer_cls(
                 on_message=self._on_message,
                 name=self._name,
-                exchange=self._exchange,
                 broker_url=self._broker_url,
-                queue=self._queue,
-                routing_key=self._routing_key,
+                task_routing=self._task_routing,
                 app_id=self._app_id,
                 recover_from=self._recover_from,
             )

--- a/neo4j-app/neo4j_app/tests/icij_worker/consumer_main.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/consumer_main.py
@@ -1,8 +1,10 @@
 import logging
 import sys
 
+from pika.exchange_type import ExchangeType
+
 from neo4j_app import icij_worker
-from neo4j_app.icij_worker import MessageConsumer
+from neo4j_app.icij_worker import Exchange, MessageConsumer, Routing
 
 _FMT = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: %(message)s"
 _DATE_FMT = "%H:%M:%S"
@@ -18,12 +20,15 @@ if __name__ == "__main__":
         handler = logging.StreamHandler()
         handler.setFormatter(logging.Formatter(_FMT, datefmt=_DATE_FMT))
         logger.addHandler(handler)
+    task_routing = Routing(
+        exchange=Exchange(name="default-ex", type=ExchangeType.topic),
+        default_queue="test-queue",
+        routing_key="test",
+    )
     consumer = MessageConsumer(
         name="test-worker",
         on_message=lambda: print("working"),
         broker_url=broker_url,
-        queue="test-queue",
-        exchange="default-ex",
-        routing_key="test",
+        task_routing=task_routing,
     )
     consumer.consume()

--- a/neo4j-app/neo4j_app/tests/icij_worker/consumer_main.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/consumer_main.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 from neo4j_app import icij_worker
-from neo4j_app.icij_worker.consumer import MessageConsumer
+from neo4j_app.icij_worker import MessageConsumer
 
 _FMT = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: %(message)s"
 _DATE_FMT = "%H:%M:%S"

--- a/neo4j-app/neo4j_app/tests/icij_worker/test_app.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/test_app.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+import pytest
+
+from neo4j_app.icij_worker import ICIJApp
+
+
+@pytest.mark.parametrize(
+    "task_name,expected_name",
+    [(None, "hello_world"), ("hello", "hello")],
+)
+def test_should_register_task_with_name(task_name: Optional[str], expected_name: str):
+    # Given
+    app = ICIJApp(name="test-app")
+
+    # When
+    if task_name is None:
+
+        @app.task
+        def hello_world():
+            pass
+
+    else:
+
+        @app.task(name=task_name)
+        def hello_world():
+            pass
+
+    # Then
+    assert expected_name in app.registry
+
+
+def test_should_raise_for_already_registered_name():
+    # Given
+    app = ICIJApp(name="test-app")
+
+    # When
+    @app.task
+    def hello_world():
+        pass
+
+    # Then
+    with pytest.raises(ValueError, match='A task "hello_world" was already registered'):
+
+        @app.task(name="hello_world")
+        def another_hello_world():
+            pass

--- a/neo4j-app/neo4j_app/tests/icij_worker/test_consumer.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/test_consumer.py
@@ -137,8 +137,7 @@ async def test_consumer_should_consume(
                 # Then
                 after_s = 1.0
                 statement = (
-                    lambda: consumer.consumed
-                    # pylint: disable=unnecessary-lambda-assignment
+                    lambda: consumer.consumed  # pylint: disable=unnecessary-lambda-assignment
                 )
                 msg = f"consumer failed to consume within {after_s}s"
                 assert true_after(statement, after_s=after_s), msg
@@ -195,8 +194,7 @@ async def test_consumer_should_reconnect_for_recoverable_error(
                 # Then
                 after_s = 1.0
                 statement = (
-                    lambda: consumer.consumed
-                    # pylint: disable=unnecessary-lambda-assignment
+                    lambda: consumer.consumed  # pylint: disable=unnecessary-lambda-assignment
                 )
                 msg = f"consumer failed to consume within {after_s}s"
                 assert true_after(statement, after_s=after_s), msg

--- a/neo4j-app/neo4j_app/tests/icij_worker/test_worker.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/test_worker.py
@@ -41,7 +41,7 @@ class _TestWorker(Worker):
 
 @mock_app.task("hello_world")
 def _hello_word(
-        greeted: str, progress_handler: Optional[ProgressHandler] = None
+    greeted: str, progress_handler: Optional[ProgressHandler] = None
 ) -> str:
     progress_handler(0.0)
     greeting = f"Hello {greeted} !"
@@ -315,7 +315,7 @@ async def test_task_worker(rabbit_mq: str, amqp_loggers, monkeypatch):
                 # Then
                 after_s = 1.0
                 statement = (
-                    lambda: worker.consumer.consumed # pylint: disable=unnecessary-lambda-assignment
+                    lambda: worker.consumer.consumed  # pylint: disable=unnecessary-lambda-assignment
                 )
                 msg = f"consumer failed to consume within {after_s}s"
                 assert true_after(statement, after_s=after_s), msg

--- a/neo4j-app/neo4j_app/tests/icij_worker/test_worker.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/test_worker.py
@@ -1,0 +1,316 @@
+import functools
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from typing import Optional
+from unittest.mock import MagicMock, call
+
+import pytest
+from pika import BlockingConnection, DeliveryMode, URLParameters
+from pika.exchange_type import ExchangeType
+from pika.spec import Basic, BasicProperties
+
+from neo4j_app.icij_worker import (
+    Exchange,
+    ICIJApp,
+    MessagePublisher,
+    Routing,
+)
+from neo4j_app.icij_worker.task import Task, TaskEvent, TaskResult, TaskStatus
+from neo4j_app.icij_worker.typing import ProgressHandler
+from neo4j_app.icij_worker.worker import task_wrapper
+from neo4j_app.tests.icij_worker.conftest import (
+    TestConsumer__,
+    async_true_after,
+    consumer_factory,
+    queue_exists,
+    shutdown_nowait,
+    true_after,
+)
+
+mock_app = ICIJApp(name="mock_app")
+
+
+@mock_app.task("hello_world")
+def _hello_word(
+    greeted: str, progress_handler: Optional[ProgressHandler] = None
+) -> str:
+    progress_handler(0.0)
+    greeting = f"Hello {greeted} !"
+    progress_handler(100.0)
+    return greeting
+
+
+class _Recovering(ValueError):
+    pass
+
+
+@mock_app.task("recovering_task", recover_from=(_Recovering,))
+def _recovering_task() -> str:
+    raise _Recovering("i can recover from this")
+
+
+@mock_app.task("fatal_error_task")
+def _fatal_error_task() -> str:
+    raise ValueError("this is fatal")
+
+
+def test_task_wrapper_should_publish_result():
+    # pylint: disable=pointless-statement
+    # Given
+    mocked_consumer = MagicMock()
+    mocked_publisher = MagicMock()
+    deliver = Basic.Deliver(delivery_tag="some-tag")
+    properties = BasicProperties()
+    task = Task(
+        id="some-id",
+        type="hello_world",
+        created_at=datetime.now().isoformat(),
+        status=TaskStatus.CREATED,
+        inputs={"greeted": "world"},
+    )
+    body = task.json().encode()
+
+    # When
+    task_wrapper(
+        basic_deliver=deliver,
+        properties=properties,
+        consumer=mocked_consumer,
+        publisher=mocked_publisher,
+        app=mock_app,
+        body=body,
+    )
+
+    # Then
+    mocked_consumer.acknowledge_message.assert_not_called
+    mocked_consumer.reject_message.assert_not_called
+    mocked_consumer.log.assert_called_with(
+        logging.INFO, "task %s successful !", task.id
+    )
+    expected_results = TaskResult(task_id=task.id, result="Hello world !")
+    mocked_publisher.publish_task_result.assert_called_with(expected_results)
+    expected_events = [
+        call(TaskEvent(task_id="some-id", progress=0.0), mandatory=False),
+        call(TaskEvent(task_id="some-id", progress=100.0), mandatory=False),
+        call(
+            TaskEvent(
+                task_id="some-id",
+                status=TaskStatus.DONE,
+                progress=100.0,
+            ),
+            mandatory=False,
+        ),
+    ]
+    assert mocked_publisher.publish_task_event.call_args_list == expected_events
+    mocked_publisher.publish_task_error.assert_not_called
+
+
+def test_task_wrapper_should_recover_from_recoverable_error():
+    # pylint: disable=pointless-statement
+    # Given
+    mocked_consumer = MagicMock()
+    mocked_publisher = MagicMock()
+    deliver = Basic.Deliver(delivery_tag="some-tag")
+    properties = BasicProperties()
+    task = Task(
+        id="some-id",
+        type="recovering_task",
+        created_at=datetime.now().isoformat(),
+        status=TaskStatus.CREATED,
+    )
+    body = task.json().encode()
+
+    # When
+    task_wrapper(
+        basic_deliver=deliver,
+        properties=properties,
+        consumer=mocked_consumer,
+        publisher=mocked_publisher,
+        app=mock_app,
+        body=body,
+    )
+
+    # Then
+    mocked_consumer.acknowledge_message.assert_not_called
+    mocked_consumer.reject_message.assert_called_with(
+        delivery_tag=deliver.delivery_tag, requeue=True
+    )
+    mocked_publisher.publish_task_result.assert_not_called
+    assert mocked_publisher.publish_task_event.call_count == 1
+    published_event = mocked_publisher.publish_task_event.mock_calls[0].args[0]
+    assert published_event.task_id == "some-id"
+    assert published_event.status is TaskStatus.RETRY
+    assert published_event.progress is None
+    assert '_Recovering("i can recover from this")' in published_event.error
+    mocked_publisher.publish_task_error.assert_not_called
+
+
+def test_task_wrapper_should_handle_non_recoverable_error():
+    # pylint: disable=pointless-statement
+    # Given
+    mocked_consumer = MagicMock()
+    mocked_publisher = MagicMock()
+    deliver = Basic.Deliver(delivery_tag="some-tag")
+    properties = BasicProperties()
+    task = Task(
+        id="some-id",
+        type="fatal_error_task",
+        created_at=datetime.now().isoformat(),
+        status=TaskStatus.CREATED,
+    )
+    body = task.json().encode()
+
+    # When
+    task_wrapper(
+        basic_deliver=deliver,
+        properties=properties,
+        consumer=mocked_consumer,
+        publisher=mocked_publisher,
+        app=mock_app,
+        body=body,
+    )
+
+    # Then
+    mocked_consumer.acknowledge_message.assert_not_called
+    mocked_consumer.reject_message.assert_called_with(
+        delivery_tag=deliver.delivery_tag, requeue=False
+    )
+    mocked_publisher.publish_task_result.assert_not_called
+    assert mocked_publisher.publish_task_event.call_count == 1
+    published_event = mocked_publisher.publish_task_event.mock_calls[0].args[0]
+    assert published_event.task_id == "some-id"
+    assert published_event.progress is None
+    assert published_event.status is TaskStatus.ERROR
+    assert 'ValueError("this is fatal")' in published_event.error
+    mocked_publisher.publish_task_error.assert_called_once
+    published_error = mocked_publisher.publish_task_error.mock_calls[0].args[0]
+    assert published_error.task_id == "some-id"
+    assert published_error.title == "ValueError"
+    assert 'ValueError("this is fatal")' in published_error.detail
+
+
+def test_task_wrapper_should_handle_unregistered_task():
+    # pylint: disable=pointless-statement
+    # Given
+    mocked_consumer = MagicMock()
+    mocked_publisher = MagicMock()
+    deliver = Basic.Deliver(delivery_tag="some-tag")
+    properties = BasicProperties()
+    task = Task(
+        id="some-id",
+        type="i_dont_exist",
+        created_at=datetime.now().isoformat(),
+        status=TaskStatus.CREATED,
+    )
+    body = task.json().encode()
+
+    # When
+    task_wrapper(
+        basic_deliver=deliver,
+        properties=properties,
+        consumer=mocked_consumer,
+        publisher=mocked_publisher,
+        app=mock_app,
+        body=body,
+    )
+
+    # Then
+    mocked_consumer.acknowledge_message.assert_not_called
+    mocked_consumer.reject_message.assert_called_with(
+        delivery_tag=deliver.delivery_tag, requeue=False
+    )
+    mocked_publisher.publish_task_result.assert_not_called
+    assert mocked_publisher.publish_task_event.call_count == 1
+    published_event = mocked_publisher.publish_task_event.mock_calls[0].args[0]
+    assert published_event.task_id == "some-id"
+    assert published_event.progress is None
+    assert published_event.status is TaskStatus.ERROR
+    mocked_publisher.publish_task_error.assert_called_once
+    expected_msg = 'UnregisteredTask task "i_dont_exist", available tasks: '
+    assert published_event.error is not None
+    assert expected_msg in published_event.error
+    published_error = mocked_publisher.publish_task_error.mock_calls[0].args[0]
+    assert published_error.task_id == "some-id"
+    assert published_error.title == "UnregisteredTask"
+    expected_msg = 'UnregisteredTask task "i_dont_exist", available tasks: '
+    assert expected_msg in published_error.detail
+
+
+@pytest.mark.asyncio
+async def test_task_wrapper_integration(rabbit_mq: str, amqp_loggers):
+    # pylint: disable=unused-argument
+    # Given
+    broker_url = rabbit_mq
+    app_id = "datashare"
+    task_key = "datashare.task.ping"
+    task_exchange = "task-ex"
+    task_queue = "task-queue"
+    event_routing = Routing(
+        exchange=Exchange(name="event-ex", type=ExchangeType.fanout),
+        routing_key="datashare.event.ping",
+        default_queue="ping-queue",
+    )
+    error_routing = Routing(
+        exchange=Exchange(name="error-ex", type=ExchangeType.topic),
+        routing_key="datashare.error.ping",
+        default_queue="error-queue",
+    )
+    result_routing = Routing(
+        exchange=Exchange(name="result-ex", type=ExchangeType.topic),
+        routing_key="datashare.result.ping",
+        default_queue="result-queue",
+    )
+    publisher = MessagePublisher(
+        name="test-publisher",
+        event_routing=event_routing,
+        error_routing=error_routing,
+        result_routing=result_routing,
+        broker_url=broker_url,
+        app_id=app_id,
+    )
+    consumer_cls = consumer_factory(TestConsumer__, n_failures=0)
+    on_message = functools.partial(task_wrapper, publisher=publisher, app=mock_app)
+    consumer = consumer_cls(
+        on_message=on_message,
+        name="test-consumer",
+        exchange=task_exchange,
+        broker_url=broker_url,
+        queue=task_queue,
+        routing_key=task_key,
+    )
+
+    with publisher.connect():
+        task = Task(
+            id="some-id",
+            type="hello_world",
+            created_at=datetime.now().isoformat(),
+            status=TaskStatus.CREATED,
+            inputs={"greeted": "world"},
+        )
+        body = task.json().encode()
+
+        # When
+        with shutdown_nowait(ThreadPoolExecutor()) as executor:
+            with consumer:
+                executor.submit(consumer.consume)
+                has_queue = functools.partial(queue_exists, task_queue)
+                await async_true_after(has_queue, after_s=1.0)
+                with BlockingConnection(URLParameters(broker_url)) as connection:
+                    with connection.channel() as channel:
+                        channel.basic_publish(
+                            task_exchange,
+                            task_key,
+                            body,
+                            BasicProperties(
+                                content_type="text/plain",
+                                delivery_mode=DeliveryMode.Transient,
+                            ),
+                        )
+
+                        # Then
+                        after_s = 1.0
+                        statement = (
+                            lambda: consumer.consumed  # pylint: disable=unnecessary-lambda-assignment
+                        )
+                        msg = f"consumer failed to consume within {after_s}s"
+                        assert true_after(statement, after_s=after_s), msg


### PR DESCRIPTION
# Before merging
- [x] merge #43
- [x] merge #44

# PR description

This PR implements the chore of the asynchronous Python worker. It enables registers Python functions as asynchronous tasks.

Given the following function:
```python
def hello_world(greeted: str) -> str:
    greeting = f"Hello {greeted} !"
    return greeting
```
the `ICIJApp` class enables us to register it so that it's then performed by an async worker:
```python

app = ICIJApp(name="my_app")

@app.task
def hello_world(greeted: str) -> str:
    greeting = f"Hello {greeted} !"
    return greeting
```
this will register the `hello_world` function under the `hello_world` task name. Another name can be specified using `name` argument of the decorator:
```python
@app.task(name="another_task_name")
def hello_world(greeted: str) -> str:
    greeting = f"Hello {greeted} !"
    return greeting
```


tasks can support progress handlers:
```python
@app.task
def hello_world(greeted: str, progress_handler: Callable[[float], None]) -> str:
    progress_handler(0.0)
    greeting = f"Hello {greeted} !"
    progress_handler(100.0)
    return greeting
```


**The only requirement for a function to be wrapped as a task is that its inputs and output are JSON serializable**.

Additionally in order to perform tasks, a `Worker` class has been introduced. This object wraps a consumer and a publisher and is able to:
- grab a task to be performed
- try to perform it
- publish task updates events
- publish task errors
- publish task results
- recover from the running task recoverable errors

Worker can be created and launched this way:

```python
task_routing = Routing(
    exchange=Exchange(name="task-exchange", type=ExchangeType.topic),
    routing_key="datashare.task",
    default_queue="task-queue",
)
publisher = MessagePublisher(...)
worker = Worker(
    name="my-worker",
    app=app,
    task_routing=task_routing,
    publisher=publisher
)
worker.work()
```


Task recoverable errors can be specified using the `recover_from` arguments of the `task` decorator:
```python
@app.task(recover_from=(MyBusinessLogicRecoverableError))
```
The errors specified this way must be business logic related errors, not AMQP related recoverable errors (which are handled using the `Worker.__init__` and `MessagePublisher.__init__` `recover_from` arguments).


# Change

## `datashare-extension-neo4j/neo4j-app`
### Added
- Implemented the `ICIJApp` task registry
- Implemented the `task_wrapper` function which handles the task business logic and AMQP workflow:
	- when a valid task is passed to the wrapper, it's retrieved from the registry and the task inputs are forwarded to the task function. The task result is then published using the `publisher`. If the task supports progress, the `publisher` will also post progress updates. The task message final acknowledgement is left to the outer body of the wrapper
	- in case of a recoverable error (identified inspecting the task registry), the task message will be requeued (endlessly for now, we'll work on reducing the number of retries in a later PR)
	- in case of a non recoverable error, the task is acknowledged (so that it's not redelivered) and the publisher publishes it to the error queue (as well as publishing some task update event)


# Left for later
- handle a maximum number of retries per task
- infer the task name from the function name (if relevant...)