### PR TITLE
chore: improve error handling before extension startup

### DIFF
--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -14,6 +14,7 @@ from pydantic import Field, validator
 
 from neo4j_app.core.elasticsearch import ESClientABC
 from neo4j_app.core.elasticsearch.client import ESClient, OSClient
+from neo4j_app.core.utils.logging import DATE_FMT, STREAM_HANDLER_FMT
 from neo4j_app.core.utils.pydantic import (
     BaseICIJModel,
     IgnoreExtraModel,
@@ -22,8 +23,6 @@ from neo4j_app.core.utils.pydantic import (
 
 _SYSLOG_MODEL_SPLIT_CHAR = "@"
 _SYSLOG_FMT = f"%(name)s{_SYSLOG_MODEL_SPLIT_CHAR}%(message)s"
-_STREAM_HANDLER_FMT = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: %(message)s"
-_DATE_FMT = "%H:%M:%S"
 
 
 def _es_version():
@@ -195,7 +194,7 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     @functools.cached_property
     def _handlers(self) -> List[logging.Handler]:
         stream_handler = logging.StreamHandler(sys.stderr)
-        stream_handler.setFormatter(logging.Formatter(_STREAM_HANDLER_FMT, _DATE_FMT))
+        stream_handler.setFormatter(logging.Formatter(STREAM_HANDLER_FMT, DATE_FMT))
         handlers = [stream_handler]
         if self.neo4j_app_syslog_facility is not None:
             syslog_handler = SysLogHandler(

--- a/neo4j-app/neo4j_app/core/utils/logging.py
+++ b/neo4j-app/neo4j_app/core/utils/logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import logging
 from datetime import datetime
@@ -40,3 +42,7 @@ def log_elapsed_time_cm(
     if "elapsed_time" in output_msg:
         msg_fmt["elapsed_time"] = end
     logger.log(level, output_msg.format(**msg_fmt))
+
+
+STREAM_HANDLER_FMT = "[%(levelname)s][%(asctime)s.%(msecs)03d][%(name)s]: %(message)s"
+DATE_FMT = "%H:%M:%S"

--- a/neo4j-app/neo4j_app/tests/run/test_run.py
+++ b/neo4j-app/neo4j_app/tests/run/test_run.py
@@ -32,4 +32,6 @@ def test_should_read_java_properties(tmpdir: Path):
     # Then
     assert exception.returncode == 1
     assert "Provided config path does not exists" in exception.stderr
+    # Check that the logger was used
+    assert "ERROR" in exception.stderr
     assert str(missing_config_file_path) in exception.stderr


### PR DESCRIPTION
# Changes

## `datashare-neo4j-extension/neo4j-app`
### Added
- Temporarily setup loggers in the main scripts before loggers are properly set using the logging config. This enables to log error even loggers have not been configure yet. This typically happens and invalid configuration is provided