### PR TITLE
fix: project support

### DIFF
--- a/neo4j-app/neo4j_app/app/admin.py
+++ b/neo4j-app/neo4j_app/app/admin.py
@@ -36,6 +36,7 @@ def admin_router() -> APIRouter:
     )
     async def _neo4j_csv(
         database: str,
+        index: str,
         payload: Neo4jCSVRequest,
         request: Request,
         es_client: ESClientABC = Depends(es_client_dep),
@@ -50,6 +51,7 @@ def admin_router() -> APIRouter:
                 export_dir=Path(tmpdir),
                 es_query=payload.query,
                 es_client=es_client,
+                es_index=index,
                 es_concurrency=config.es_max_concurrency,
                 es_keep_alive=config.es_keep_alive,
                 es_doc_type_field=config.es_doc_type_field,

--- a/neo4j-app/neo4j_app/app/documents.py
+++ b/neo4j-app/neo4j_app/app/documents.py
@@ -28,6 +28,7 @@ def documents_router() -> APIRouter:
     )
     async def _import_documents(
         database: str,
+        index: str,
         payload: IncrementalImportRequest,
         request: Request,
         neo4j_driver: neo4j.AsyncDriver = Depends(neo4j_driver_dep),
@@ -39,6 +40,7 @@ def documents_router() -> APIRouter:
         ):
             res = await import_documents(
                 es_client=es_client,
+                es_index=index,
                 es_query=payload.query,
                 es_concurrency=es_client.max_concurrency,
                 es_keep_alive=config.es_keep_alive,

--- a/neo4j-app/neo4j_app/app/named_entities.py
+++ b/neo4j-app/neo4j_app/app/named_entities.py
@@ -28,6 +28,7 @@ def named_entities_router() -> APIRouter:
     )
     async def _import_named_entities(
         database: str,
+        index: str,
         payload: IncrementalImportRequest,
         request: Request,
         neo4j_driver: neo4j.AsyncDriver = Depends(neo4j_driver_dep),
@@ -39,6 +40,7 @@ def named_entities_router() -> APIRouter:
         ):
             res = await import_named_entities(
                 es_client=es_client,
+                es_index=index,
                 es_query=payload.query,
                 es_concurrency=es_client.max_concurrency,
                 es_keep_alive=config.es_keep_alive,

--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -55,7 +55,6 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     neo4j_import_batch_size: int = int(5e5)
     neo4j_password: Optional[str] = None
     neo4j_port: int = 7687
-    neo4j_project: str
     neo4j_transaction_batch_size = 50000
     neo4j_user: Optional[str] = None
     # Other supported schemes are neo4j+ssc, neo4j+s, bolt, bolt+ssc, bolt+s
@@ -174,7 +173,6 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
         client_cls = OSClient if self.neo4j_app_uses_opensearch else ESClient
         # TODO: read the index name in a secure manner...
         client = client_cls(
-            project_index=self.neo4j_project,
             hosts=[self.es_host],
             port=self.es_port,
             pagination=self.es_default_page_size,

--- a/neo4j-app/neo4j_app/tests/app/test_admin.py
+++ b/neo4j-app/neo4j_app/tests/app/test_admin.py
@@ -1,6 +1,5 @@
 import os
 import stat
-
 from pathlib import Path
 
 import pytest
@@ -14,7 +13,7 @@ from neo4j_app.core.objects import (
     NodeCSVs,
     RelationshipCSVs,
 )
-from neo4j_app.tests.conftest import populate_es_with_doc_and_named_entities
+from neo4j_app.tests.conftest import TEST_INDEX, populate_es_with_doc_and_named_entities
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -31,7 +30,7 @@ async def test_post_named_entities_import_should_return_200(
     # Given
     test_client = test_client_module
     query = {"ids": {"values": ["doc-0"]}}
-    url = "/admin/neo4j-csvs?database=neo4j"
+    url = f"/admin/neo4j-csvs?database=neo4j&index={TEST_INDEX}"
     payload = {"query": query}
 
     # When

--- a/neo4j-app/neo4j_app/tests/app/test_documents.py
+++ b/neo4j-app/neo4j_app/tests/app/test_documents.py
@@ -7,13 +7,13 @@ from starlette.testclient import TestClient
 
 from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.core.objects import IncrementalImportResponse
-from neo4j_app.tests.conftest import index_docs
+from neo4j_app.tests.conftest import TEST_INDEX, index_docs
 
 
 @pytest_asyncio.fixture(scope="module")
 async def _populate_es(es_test_client_module: ESClient):
     es_client = es_test_client_module
-    index_name = es_client.project_index
+    index_name = TEST_INDEX
     n_docs = 10
     async for _ in index_docs(es_client, index_name=index_name, n=n_docs):
         pass
@@ -49,7 +49,7 @@ def test_post_documents_import_should_return_200(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = "/documents?database=neo4j"
+    url = f"/documents?database=neo4j&index={TEST_INDEX}"
     payload = {}
     if query is not None:
         payload["query"] = query

--- a/neo4j-app/neo4j_app/tests/app/test_named_entities.py
+++ b/neo4j-app/neo4j_app/tests/app/test_named_entities.py
@@ -7,7 +7,7 @@ from starlette.testclient import TestClient
 
 from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.core.objects import IncrementalImportResponse
-from neo4j_app.tests.conftest import populate_es_with_doc_and_named_entities
+from neo4j_app.tests.conftest import TEST_INDEX, populate_es_with_doc_and_named_entities
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -44,7 +44,7 @@ def test_post_named_entities_import_should_return_200(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = "/named-entities?database=neo4j"
+    url = f"/named-entities?database=neo4j&index={TEST_INDEX}"
     payload = {}
     if query is not None:
         payload["query"] = query

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_imports.py
@@ -33,6 +33,7 @@ async def test_neo4_import_worker(
 ):
     # Given
     neo4j_driver = neo4j_test_driver
+    neo4j_db = "neo4j"
     transaction_batch_size = 2
     num_records = 22
     import_batch_size = 3
@@ -41,7 +42,7 @@ async def test_neo4_import_worker(
         Neo4jImportWorker(
             f"worker-{i}",
             neo4j_driver=neo4j_driver,
-            neo4j_db=neo4j.DEFAULT_DATABASE,
+            neo4j_db=neo4j_db,
             import_fn=_dummy_import,
             transaction_batch_size=transaction_batch_size,
         )

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
@@ -60,12 +60,12 @@ async def test_import_named_entities(
     assert n_created_second == expected_n_nodes - n_created_first
     query = """
 MATCH (ent:NamedEntity)
-RETURN ent as ent, labels(ent) as entLabels
+RETURN ent as ent, apoc.coll.sort(labels(ent)) as entLabels
 ORDER BY entLabels"""
     res = await neo4j_test_session.run(query)
     ents = [(rec["ent"]["mentionNorm"], rec["entLabels"]) async for rec in res]
     expected_ents = [
-        ("mention-0", ["NamedEntity", "Location"]),
+        ("mention-0", ["Location", "NamedEntity"]),
         ("mention-0", ["NamedEntity", "Person"]),
     ]
     assert ents == expected_ents

--- a/neo4j-app/neo4j_app/tests/core/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/test_imports.py
@@ -36,6 +36,7 @@ from neo4j_app.core.objects import (
 from neo4j_app.tests.conftest import (
     NEO4J_TEST_AUTH,
     NEO4J_TEST_PORT,
+    TEST_INDEX,
     assert_content,
     index_docs,
     index_named_entities,
@@ -48,7 +49,7 @@ async def _populate_es(
     es_test_client_module: ESClient,
 ) -> AsyncGenerator[ESClient, None]:
     es_client = es_test_client_module
-    index_name = es_client.project_index
+    index_name = TEST_INDEX
     n = 20
     # Index some Documents
     async for _ in index_docs(es_client, index_name=index_name, n=n):
@@ -116,6 +117,7 @@ async def test_import_documents(
 
     # When
     response = await import_documents(
+        es_index=TEST_INDEX,
         es_client=es_client,
         es_query=query,
         es_keep_alive="10s",
@@ -159,6 +161,7 @@ async def test_import_documents_should_forward_db(
         with patch.object(neo4j_driver, attribute="session", new=mock_session):
             # When/Then
             res = await import_documents(
+                es_index=TEST_INDEX,
                 es_client=es_client,
                 es_query=dict(),
                 es_keep_alive="10s",
@@ -238,6 +241,7 @@ async def test_import_named_entities(
     # When
     response = await import_named_entities(
         es_client=es_client,
+        es_index=TEST_INDEX,
         es_query=query,
         es_keep_alive="10s",
         es_doc_type_field=doc_type_field,
@@ -274,6 +278,7 @@ async def test_should_aggregate_named_entities_attributes_on_relationship(
     await import_named_entities(
         es_client=es_client,
         es_query=query,
+        es_index=TEST_INDEX,
         es_keep_alive="10s",
         es_doc_type_field="type",
         neo4j_driver=neo4j_driver,
@@ -337,6 +342,7 @@ async def test_import_named_entities_should_forward_db(
             await import_named_entities(
                 es_client=es_client,
                 es_query=dict(),
+                es_index=TEST_INDEX,
                 es_keep_alive="10s",
                 es_doc_type_field="type",
                 neo4j_driver=neo4j_driver,
@@ -444,6 +450,7 @@ async def test_to_neo4j_csvs(_populate_es: ESClient, tmpdir):
     # When
     res = await to_neo4j_csvs(
         es_query=es_query,
+        es_index=TEST_INDEX,
         export_dir=export_dir,
         es_client=es_client,
         es_concurrency=None,

--- a/neo4j-app/poetry.lock
+++ b/neo4j-app/poetry.lock
@@ -431,13 +431,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
-version = "0.89.1"
+version = "0.99.1"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "fastapi-0.89.1-py3-none-any.whl", hash = "sha256:f9773ea22290635b2f48b4275b2bf69a8fa721fda2e38228bed47139839dc877"},
-    {file = "fastapi-0.89.1.tar.gz", hash = "sha256:15d9271ee52b572a015ca2ae5c72e1ce4241dd8532a534ad4f7ec70c376a580f"},
+    {file = "fastapi-0.99.1-py3-none-any.whl", hash = "sha256:976df7bab51ac7beda9f68c4513b8c4490b5c1135c72aafd0a5ee4023ec5282e"},
+    {file = "fastapi-0.99.1.tar.gz", hash = "sha256:ac78f717cd80d657bd183f94d33b9bda84aa376a46a9dab513586b8eef1dc6fc"},
 ]
 
 [package.dependencies]
@@ -446,18 +446,16 @@ httpx = {version = ">=0.23.0", optional = true, markers = "extra == \"all\""}
 itsdangerous = {version = ">=1.1.0", optional = true, markers = "extra == \"all\""}
 jinja2 = {version = ">=2.11.2", optional = true, markers = "extra == \"all\""}
 orjson = {version = ">=3.2.1", optional = true, markers = "extra == \"all\""}
-pydantic = ">=1.6.2,<1.7 || >1.7,<1.7.1 || >1.7.1,<1.7.2 || >1.7.2,<1.7.3 || >1.7.3,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0"
 python-multipart = {version = ">=0.0.5", optional = true, markers = "extra == \"all\""}
 pyyaml = {version = ">=5.3.1", optional = true, markers = "extra == \"all\""}
-starlette = "0.22.0"
+starlette = ">=0.27.0,<0.28.0"
+typing-extensions = ">=4.5.0"
 ujson = {version = ">=4.0.1,<4.0.2 || >4.0.2,<4.1.0 || >4.1.0,<4.2.0 || >4.2.0,<4.3.0 || >4.3.0,<5.0.0 || >5.0.0,<5.1.0 || >5.1.0", optional = true, markers = "extra == \"all\""}
 uvicorn = {version = ">=0.12.0", extras = ["standard"], optional = true, markers = "extra == \"all\""}
 
 [package.extras]
 all = ["email-validator (>=1.1.1)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=2.11.2)", "orjson (>=3.2.1)", "python-multipart (>=0.0.5)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
-dev = ["pre-commit (>=2.17.0,<3.0.0)", "ruff (==0.0.138)", "uvicorn[standard] (>=0.12.0,<0.21.0)"]
-doc = ["mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-markdownextradata-plugin (>=0.1.7,<0.3.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pyyaml (>=5.3.1,<7.0.0)", "typer[all] (>=0.6.1,<0.8.0)"]
-test = ["anyio[trio] (>=3.2.1,<4.0.0)", "black (==22.10.0)", "coverage[toml] (>=6.5.0,<8.0)", "databases[sqlite] (>=0.3.2,<0.7.0)", "email-validator (>=1.1.1,<2.0.0)", "flask (>=1.1.2,<3.0.0)", "httpx (>=0.23.0,<0.24.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.982)", "orjson (>=3.2.1,<4.0.0)", "passlib[bcrypt] (>=1.7.2,<2.0.0)", "peewee (>=3.13.3,<4.0.0)", "pytest (>=7.1.3,<8.0.0)", "python-jose[cryptography] (>=3.3.0,<4.0.0)", "python-multipart (>=0.0.5,<0.0.6)", "pyyaml (>=5.3.1,<7.0.0)", "ruff (==0.0.138)", "sqlalchemy (>=1.3.18,<1.4.43)", "types-orjson (==3.6.2)", "types-ujson (==5.6.0.0)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,<6.0.0)"]
 
 [[package]]
 name = "frozenlist"
@@ -1346,13 +1344,13 @@ files = [
 
 [[package]]
 name = "starlette"
-version = "0.22.0"
+version = "0.27.0"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "starlette-0.22.0-py3-none-any.whl", hash = "sha256:b5eda991ad5f0ee5d8ce4c4540202a573bb6691ecd0c712262d0bc85cf8f2c50"},
-    {file = "starlette-0.22.0.tar.gz", hash = "sha256:b092cbc365bea34dd6840b42861bdabb2f507f8671e642e8272d2442e08ea4ff"},
+    {file = "starlette-0.27.0-py3-none-any.whl", hash = "sha256:918416370e846586541235ccd38a474c08b80443ed31c578a418e2209b3eef91"},
+    {file = "starlette-0.27.0.tar.gz", hash = "sha256:6a6b0d042acb8d469a01eba54e9cda6cbd24ac602c4cd016723117d6a7e73b75"},
 ]
 
 [package.dependencies]
@@ -1841,4 +1839,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "7cdf39beaabfc53d32bcb8552585c54eaf9c6fc7ba2f3e493f1bf45540b8c217"
+content-hash = "54bd8bf9ca755d6b12c2165607753b2c4a23f6e5cfee7348f14e556e4e558204"

--- a/neo4j-app/pyproject.toml
+++ b/neo4j-app/pyproject.toml
@@ -15,7 +15,7 @@ target = "py38"
 
 [tool.poetry.dependencies]
 python = "^3.9"
-fastapi = "^0.89.1"
+fastapi = "^0.99.1"
 pyyaml = ">=5.4.0" # For security
 uvicorn = { version = "^0.20.0", extras = ["standard"] }
 elasticsearch = {version = "<7.14", extras = ["async"]}
@@ -24,7 +24,7 @@ setuptools = "^67.6.1"
 datrie = "^0.8.2"
 
 [tool.poetry.group.dev.dependencies]
-fastapi = { version = "^0.89.1", extras = ["all"] }
+fastapi = { version = "^0.99.1", extras = ["all"] }
 pylint = "^2.15.10"
 pytest = "^7.2.1"
 pytest-asyncio = "^0.20.3"

--- a/src/main/java/org/icij/datashare/Neo4jClient.java
+++ b/src/main/java/org/icij/datashare/Neo4jClient.java
@@ -20,9 +20,9 @@ public class Neo4jClient {
     }
 
     public Objects.IncrementalImportResponse importDocuments(
-        String database, Objects.IncrementalImportRequest body
+        String database, String  index, Objects.IncrementalImportRequest body
     ) {
-        String url = buildNeo4jUrl("/documents?database=" + database);
+        String url = buildNeo4jUrl("/documents?database=" + database + "&index=" + index);
         logger.debug("Importing documents to neo4j with request: {}",
             lazy(() -> MAPPER.writeValueAsString(body)));
         return doHttpRequest(
@@ -33,9 +33,9 @@ public class Neo4jClient {
     }
 
     public Objects.IncrementalImportResponse importNamedEntities(
-        String database, Objects.IncrementalImportRequest body
+        String database, String index, Objects.IncrementalImportRequest body
     ) {
-        String url = buildNeo4jUrl("/named-entities?database=" + database);
+        String url = buildNeo4jUrl("/named-entities?database=" + database  + "&index=" + index);
         logger.debug("Importing named entities to neo4j with request: {}",
             lazy(() -> MAPPER.writeValueAsString(body)));
         return doHttpRequest(
@@ -47,9 +47,9 @@ public class Neo4jClient {
 
     //CHECKSTYLE.OFF: AbbreviationAsWordInName
     public Objects.Neo4jCSVResponse exportNeo4jCSVs(
-        String database, Objects.Neo4jAppNeo4jCSVRequest body
+        String database, String index, Objects.Neo4jAppNeo4jCSVRequest body
     ) {
-        String url = buildNeo4jUrl("/admin/neo4j-csvs?database=" + database);
+        String url = buildNeo4jUrl("/admin/neo4j-csvs?database=" + database  + "&index=" + index);
         logger.debug("Exporting data to neo4j csv with request: {}",
             lazy(() -> MAPPER.writeValueAsString(body)));
         return doHttpRequest(

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -366,7 +366,7 @@ public class Neo4jResource {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
         String db = neo4jProjectDatabase(projectId);
-        return client.importDocuments(db, request);
+        return client.importDocuments(db, projectId, request);
     }
 
     protected org.icij.datashare.Objects.IncrementalImportResponse importNamedEntities(
@@ -375,12 +375,12 @@ public class Neo4jResource {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
         String db = neo4jProjectDatabase(projectId);
-        return client.importNamedEntities(db, request);
+        return client.importNamedEntities(db, projectId, request);
     }
 
     //CHECKSTYLE.OFF: AbbreviationAsWordInName
     protected InputStream exportNeo4jCSVs(
-        String projectId, org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest request
+        String projectId,  org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest request
     )
         throws IOException, InterruptedException {
         // TODO: the database should be chosen dynamically with the Mode (local vs. server) and
@@ -392,7 +392,7 @@ public class Neo4jResource {
         Path exportDir = null;
         try {
             org.icij.datashare.Objects.Neo4jCSVResponse res =
-                client.exportNeo4jCSVs(database, request);
+                client.exportNeo4jCSVs(database, projectId, request);
             logger.info("Exported data from ES to neo4j, statistics: {}",
                 lazy(() -> MAPPER.writeValueAsString(res.metadata)));
             exportDir = Paths.get(res.path);


### PR DESCRIPTION
# PR description

While multiple project had been properly added on the `neo4j` side in #37, the extension was still setup to use a single index on the ES side and hence was not properly configuredfor a server usage. This PR adds a proper support of multiproject on the ES side.

# Changes

## `datashare-neo4j-extension/src`
### Changed
- Forward the project `index` alongside the project `database` in `importNamedEntities`, `importDocuments` and `exportNeo4jCSVs`

## `datashare-neo4j-extension/neo4j-app`
### Remove
- Removed the `AppConfig.neo4j_project` attribute


### Changed
- Removed the `ESClient.project_index` attribute, the ES client now takes the index as method arguments
- Updated the `POST /neo4j-csvs`, `POST /documents`, `POST /named-entities` and underlying `neo4j.core.import` functions to take the ES index as input