### PR TITLE
fix: es client creation

### DIFF
--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -3,8 +3,9 @@ import asyncio
 import contextlib
 import os
 import random
+import traceback
 from pathlib import Path
-from typing import Any, AsyncGenerator, Dict, Generator, Tuple, Union
+from typing import Any, AsyncGenerator, Dict, Generator, Optional, Tuple, Union
 
 import neo4j
 import pytest
@@ -422,3 +423,14 @@ def xml_elements_equal(actual, expected) -> bool:
     if len(actual) != len(expected):
         return False
     return all(xml_elements_equal(c1, c2) for c1, c2 in zip(actual, expected))
+
+
+@contextlib.contextmanager
+def fail_if_exception(msg: Optional[str] = None):
+    try:
+        yield
+    except Exception as e:  # pylint: disable=W0703
+        trace = "".join(traceback.format_exception(None, e, e.__traceback__))
+        if msg is None:
+            msg = "Test failed due to the following error"
+        pytest.fail(f"{msg}\n{trace}")

--- a/neo4j-app/neo4j_app/tests/core/test_config.py
+++ b/neo4j-app/neo4j_app/tests/core/test_config.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import ValidationError
 
 from neo4j_app.core import AppConfig, UviCornModel
+from neo4j_app.tests.conftest import fail_if_exception
 
 
 def test_should_support_alias():
@@ -89,16 +90,16 @@ def test_to_uvicorn(config: AppConfig, expected_uvicorn_config: UviCornModel):
     assert uvicorn_config == expected_uvicorn_config
 
 
-def test_should_parse_elasticsearch_address():
+@pytest.mark.pull(id="")
+def test_should_support_address_without_port():
     # Given
     config = AppConfig(
-        elasticsearch_address="http://elasticsearch:9222",
+        elasticsearch_address="http://elasticsearch",
         neo4j_project="test-project",
     )
     # Then
-    assert config.es_host == "elasticsearch"
-    assert config.es_port == 9222
-    assert config.es_hosts == [{"host": "elasticsearch", "port": 9222}]
+    with fail_if_exception("Failed to initialize ES client"):
+        config.to_es_client()
 
 
 @pytest.mark.parametrize("user,password", [(None, "somepass"), ("someuser", None)])


### PR DESCRIPTION
# Bug description

The Python extension is performing some parsing of the ES address in order to separate the host and port  and provide them at the client initialization. This is not needed and done was the wrong way.

# Changes
## `datashare-neo4j-extension/neo4j-app`
### Fix
- Fixed the `ESClient` creation  by simply forwarding the provided ES address (which is properly handled by the client)
