### PR TITLE
fix: migrate all projects

### DIFF
--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -7,7 +7,7 @@ from typing import Dict, Iterable, List, Optional, TextIO, Tuple
 
 from .imports import Neo4Import, Neo4jImportWorker
 from .migrations import Migration
-from .migrations.migrate import MigrationError, migrate_db_schema
+from .migrations.migrate import MigrationError, migrate_db_schemas
 from .migrations.migrations import (
     create_document_and_ne_id_unique_constraint_tx,
     create_migration_unique_constraint_tx,

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/__init__.py
@@ -1,1 +1,1 @@
-from .migrate import Migration, delete_all_migrations_tx
+from .migrate import Migration, delete_all_migrations


### PR DESCRIPTION
# Bug description

When starting the application, the only the default DB was migrated which was not suitable when using the extension with the enterprise distribution and multiple projects.

# Changes
## `datashare-neo4j-extension/neo4j-app`
### Fixed
- Renamed `migrate_db_schema` into `migrate_db_schemas` and migrate all neo4j databases

# Left for later
- For now the app will try to migrate all accessible DBs. More DBs are potentially found on the DB instance. A slight improvement to that brutal update could be to create a dedicated DB which name would be provided by config and reference all projects in that DB. This way only projects linked to this extension would be migrated