### PR TITLE
chore: harmonize error handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,7 @@
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <configLocation>qa/java/checkstyle.xml</configLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <linkXRef>false</linkXRef>

--- a/src/main/java/org/icij/datashare/HttpUtils.java
+++ b/src/main/java/org/icij/datashare/HttpUtils.java
@@ -35,7 +35,7 @@ public class HttpUtils {
 
         @Override
         public String getMessage() {
-            String msg = "Title: " + this.title;
+            String msg = this.title;
             msg += "\nDetail: " + this.detail;
             if (this.trace != null) {
                 msg += "\nTrace: " + this.trace;

--- a/src/main/java/org/icij/datashare/HttpUtils.java
+++ b/src/main/java/org/icij/datashare/HttpUtils.java
@@ -1,6 +1,7 @@
 package org.icij.datashare;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.IOException;
@@ -12,6 +13,7 @@ public class HttpUtils {
 
     // Follow the JSON error + detail spec https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-http-problem-00#page-4
     @JsonIncludeProperties({"title", "detail", "trace"})
+    @JsonIgnoreProperties(value = {"trace"})
     protected static class HttpError extends RuntimeException {
         public String title;
         public String detail;
@@ -35,8 +37,11 @@ public class HttpUtils {
 
         @Override
         public String getMessage() {
-            String msg = this.title;
-            msg += "\nDetail: " + this.detail;
+            return this.title + "\nDetail: " + this.detail;
+        }
+
+        protected String getMessageWithTrace() {
+            String msg = this.getMessage();
             if (this.trace != null) {
                 msg += "\nTrace: " + this.trace;
             }

--- a/src/main/java/org/icij/datashare/HttpUtils.java
+++ b/src/main/java/org/icij/datashare/HttpUtils.java
@@ -68,7 +68,7 @@ public class HttpUtils {
     protected static <T> T parseContext(Context context, Class<T> clazz) throws BadRequest {
         try {
             return context.extract(clazz);
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new BadRequest("Failed to parse request", e);
         }
     }

--- a/src/main/java/org/icij/datashare/HttpUtils.java
+++ b/src/main/java/org/icij/datashare/HttpUtils.java
@@ -3,39 +3,68 @@ package org.icij.datashare;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import net.codestory.http.Context;
 
 public class HttpUtils {
 
     // Follow the JSON error + detail spec https://datatracker.ietf.org/doc/html/draft-ietf-appsawg-http-problem-00#page-4
     @JsonIncludeProperties({"title", "detail", "trace"})
-    public static class HttpError extends RuntimeException {
+    protected static class HttpError extends RuntimeException {
         public String title;
         public String detail;
         public String trace;
 
         @JsonCreator
-        HttpError(
+        protected HttpError(
             @JsonProperty("title") String title,
             @JsonProperty("detail") String detail,
             @JsonProperty("trace") String trace
         ) {
-            super(title + "\nDetail: " + detail);
+            super();
             this.title = title;
             this.detail = detail;
             this.trace = trace;
         }
 
-        public HttpError(String title, String detail) {
+        protected HttpError(String title, String detail) {
             this(title, detail, null);
         }
 
         @Override
         public String getMessage() {
-            String msg = super.getMessage();
+            String msg = "Title: " + this.title;
+            msg += "\nDetail: " + this.detail;
             if (this.trace != null) {
                 msg += "\nTrace: " + this.trace;
             }
             return msg;
+        }
+    }
+
+    protected static HttpError fromException(Exception e) {
+        if (e instanceof HttpError) {
+            return (HttpError) e;
+        }
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        return new HttpError(e.getClass().getTypeName(), e.getMessage(), sw.toString());
+    }
+
+    protected static class BadRequest extends Exception {
+        protected BadRequest(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    protected static <T> T parseContext(Context context, Class<T> clazz) throws BadRequest {
+        try {
+            return context.extract(clazz);
+        } catch (IOException e) {
+            throw new BadRequest("Failed to parse request", e);
         }
     }
 }

--- a/src/main/java/org/icij/datashare/Neo4jAppLoader.java
+++ b/src/main/java/org/icij/datashare/Neo4jAppLoader.java
@@ -45,11 +45,15 @@ public class Neo4jAppLoader {
         this.propertiesProvider = propertiesProvider;
     }
 
-    public static String getExtensionVersion() throws IOException {
+    public static String getExtensionVersion() {
         Properties neo4jExtensionProps = new Properties();
         InputStream propStream = ClassLoader.getSystemResourceAsStream(
             "datashare-extension-neo4j.properties");
-        neo4jExtensionProps.load(propStream);
+        try {
+            neo4jExtensionProps.load(propStream);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed load extension properties", e);
+        }
         return Objects.requireNonNull(neo4jExtensionProps.getProperty("project.version"),
             "Couldn't find project.version in extension properties");
     }

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -500,14 +500,14 @@ public class Neo4jResource {
             return new Payload("application/problem+json", e).withCode(403);
         } catch (Neo4jNotRunningError e) {
             return new Payload("application/problem+json", e).withCode(503);
-        } catch (Neo4jClient.Neo4jAppError e) { // TODO: this should be done automatically...
+        } catch (Neo4jClient.Neo4jAppError e) {
             logger.error("internal error on the python app side {}", e.getMessage());
             return new Payload("application/problem+json", e).withCode(500);
         } catch (ForbiddenException e) {
             return new Payload("application/problem+json", fromException(e)).withCode(403);
         } catch (HttpUtils.BadRequest e) {
             return new Payload("application/problem+json", fromException(e)).withCode(400);
-        } catch (Exception e) { // TODO: this should be done automatically...
+        } catch (Exception e) {
             logger.error("internal error on the java extension side {}", e.getMessage());
             return new Payload("application/problem+json", fromException(e)).withCode(500);
         }

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -501,15 +501,20 @@ public class Neo4jResource {
         } catch (Neo4jNotRunningError e) {
             return new Payload("application/problem+json", e).withCode(503);
         } catch (Neo4jClient.Neo4jAppError e) {
-            logger.error("internal error on the python app side {}", e.getMessage());
-            return new Payload("application/problem+json", e).withCode(500);
+            HttpUtils.HttpError returned = e.toHttp();
+            logger.error(
+                "internal error on the python app side {}", returned.getMessageWithTrace()
+            );
+            return new Payload("application/problem+json", returned).withCode(500);
         } catch (ForbiddenException e) {
             return new Payload("application/problem+json", fromException(e)).withCode(403);
         } catch (HttpUtils.BadRequest e) {
             return new Payload("application/problem+json", fromException(e)).withCode(400);
         } catch (Exception e) {
-            logger.error("internal error on the java extension side {}", e.getMessage());
-            return new Payload("application/problem+json", fromException(e)).withCode(500);
+            HttpUtils.HttpError returned = fromException(e);
+            logger.error("internal error on the java extension side {}",
+                returned.getMessageWithTrace());
+            return new Payload("application/problem+json", returned).withCode(500);
         }
     }
 

--- a/src/test/java/org/icij/datashare/Neo4jAppLoaderTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jAppLoaderTest.java
@@ -77,7 +77,7 @@ public class Neo4jAppLoaderTest {
     }
 
     @Test
-    public void test_get_extension_version() throws IOException {
+    public void test_get_extension_version() {
         // When
         String version = getExtensionVersion();
         // Then

--- a/src/test/java/org/icij/datashare/Neo4jAppLoaderTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jAppLoaderTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.io.TempDir;
 
 public class Neo4jAppLoaderTest {
-    private final static String mockedBinaryName = "neo4j-app";
+    private static final String mockedBinaryName = "neo4j-app";
     @TempDir
     private static Path tmpDir;
     private static String mockedBinaryPath;

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -327,12 +327,13 @@ public class Neo4jResourceTest {
                     "foo", "null").response();
                 // Then
                 assertThat(response.code()).isEqualTo(500);
+                String expected = "neo4j Python app is already running, likely in another phantom"
+                    + " process";
                 assertJson(
                     response.content(),
                     HttpUtils.HttpError.class,
                     status -> assertThat(status.detail)
-                        .isEqualTo(
-                            "neo4j Python app is already running, likely in another phantom process")
+                        .isEqualTo(expected)
                 );
             }
         }
@@ -547,7 +548,8 @@ public class Neo4jResourceTest {
             // When
             String body = "{"
                 + "\"format\": \"graphml\", "
-                + "\"query\": {\"sort\": [{\"property\": \"path\", \"direction\": \"DESC\"}], \"limit\": 10}"
+                + "\"query\": {\"sort\": [{\"property\": \"path\", \"direction\": \"DESC\"}],"
+                + " \"limit\": 10}"
                 + "}";
             Response response = post("/api/neo4j/graphs/sorted-dump?project=foo-datashare",
                 body).withPreemptiveAuthentication("foo", "null").response();
@@ -625,10 +627,10 @@ public class Neo4jResourceTest {
                         "/admin/neo4j-csvs",
                         context -> new Payload(
                             "application/json",
-                            "{" +
-                                "\"path\": \"" + exportPathAsString + "\"," +
-                                "\"metadata\": {\"nodes\": [], \"relationships\": []}" +
-                                "}"
+                            "{"
+                                + "\"path\": \"" + exportPathAsString + "\","
+                                + "\"metadata\": {\"nodes\": [], \"relationships\": []}"
+                            + "}"
                         )
                     )
                 );
@@ -687,10 +689,10 @@ public class Neo4jResourceTest {
                         "/admin/neo4j-csvs",
                         context -> new Payload(
                             "application/json",
-                            "{" +
-                                "\"path\": \"" + exportPathAsString + "\"," +
-                                "\"metadata\": {\"nodes\": [], \"relationships\": []}" +
-                                "}"
+                            "{"
+                                + "\"path\": \"" + exportPathAsString + "\","
+                                + "\"metadata\": {\"nodes\": [], \"relationships\": []}"
+                                + "}"
                         )
                     )
                 );

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -111,8 +111,7 @@ public class Neo4jResourceTest {
         }
 
         @Override
-        public void afterEach(ExtensionContext extensionContext)
-            throws IOException, InterruptedException {
+        public void afterEach(ExtensionContext extensionContext) {
             Neo4jResource.stopServerProcess();
             reset(parentRepository);
         }
@@ -138,8 +137,7 @@ public class Neo4jResourceTest {
         }
 
         @Override
-        public void afterEach(ExtensionContext extensionContext)
-            throws IOException, InterruptedException {
+        public void afterEach(ExtensionContext extensionContext) {
             Neo4jResource.stopServerProcess();
         }
     }
@@ -151,8 +149,7 @@ public class Neo4jResourceTest {
         }
 
         @Override
-        public void afterEach(ExtensionContext extensionContext)
-            throws IOException, InterruptedException {
+        public void afterEach(ExtensionContext extensionContext) {
             Neo4jResource.stopServerProcess();
         }
     }
@@ -170,9 +167,11 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_not_be_running_by_default() throws IOException, InterruptedException {
+        public void test_not_be_running_by_default() {
             // When
-            Neo4jResource.Neo4jAppStatus status = neo4jAppResource.getStopNeo4jApp();
+            Payload payload = neo4jAppResource.getStopNeo4jApp();
+            Neo4jResource.Neo4jAppStatus status =
+                (Neo4jResource.Neo4jAppStatus) payload.rawContent();
             // Then
             assertThat(status.isRunning).isFalse();
         }
@@ -235,7 +234,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_get_status_when_running() throws IOException, InterruptedException {
+        public void test_get_status_when_running() {
             // When
             neo4jAppResource.startServerProcess(false);
             Response response =
@@ -264,8 +263,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_start_should_return_200_when_already_started()
-            throws IOException, InterruptedException {
+        public void test_post_start_should_return_200_when_already_started() {
             // When
             neo4jAppResource.startServerProcess(false);
             Response response =
@@ -294,8 +292,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_stop_should_return_200_when_already_started()
-            throws IOException, InterruptedException {
+        public void test_post_stop_should_return_200_when_already_started() {
             // When
             neo4jAppResource.startServerProcess(false);
             Response response =
@@ -322,13 +319,12 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_start_should_return_500_for_phantom_process()
-            throws InterruptedException {
+        public void test_post_start_should_return_500_for_phantom_process() {
             // Given
             try (PhantomPythonServerMock ignored = new PhantomPythonServerMock()) {
                 // When
-                Response response =
-                    post("/api/neo4j/start").withPreemptiveAuthentication("foo", "null").response();
+                Response response = post("/api/neo4j/start").withPreemptiveAuthentication(
+                    "foo", "null").response();
                 // Then
                 assertThat(response.code()).isEqualTo(500);
                 assertJson(
@@ -336,25 +332,27 @@ public class Neo4jResourceTest {
                     HttpUtils.HttpError.class,
                     status -> assertThat(status.detail)
                         .isEqualTo(
-                            "neo4j Python app is already running likely in another phantom process")
+                            "neo4j Python app is already running, likely in another phantom process")
                 );
-            } catch (IOException e) {
-                throw new RuntimeException(e);
             }
         }
 
         class PhantomPythonServerMock implements AutoCloseable {
             private final Process process;
 
-            public PhantomPythonServerMock() throws IOException, InterruptedException {
-                this.process = new ProcessBuilder(
-                    "python3",
-                    "-m",
-                    "http.server",
-                    "-d",
-                    "src/test/resources/python_mock",
-                    "8080"
-                ).start();
+            public PhantomPythonServerMock() {
+                try {
+                    this.process = new ProcessBuilder(
+                        "python3",
+                        "-m",
+                        "http.server",
+                        "-d",
+                        "src/test/resources/python_mock",
+                        "8080"
+                    ).start();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
                 neo4jAppResource.waitForServerToBeUp();
             }
 
@@ -377,8 +375,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_documents_import_should_return_200()
-            throws IOException, InterruptedException {
+        public void test_post_documents_import_should_return_200() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -426,8 +423,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_named_entities_import_should_return_200()
-            throws IOException, InterruptedException {
+        public void test_post_named_entities_import_should_return_200() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -485,8 +481,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_graph_dump_should_return_200()
-            throws IOException, InterruptedException {
+        public void test_post_graph_dump_should_return_200() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -505,8 +500,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_graph_dump_should_return_401_for_unauthorized_user()
-            throws IOException, InterruptedException {
+        public void test_post_graph_dump_should_return_401_for_unauthorized_user() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -523,8 +517,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_graph_dump_should_return_403_for_forbidden_mask()
-            throws IOException, InterruptedException {
+        public void test_post_graph_dump_should_return_403_for_forbidden_mask() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -543,8 +536,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_sorted_graph_dump_should_return_200()
-            throws IOException, InterruptedException {
+        public void test_post_sorted_graph_dump_should_return_200() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -566,8 +558,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_sorted_graph_dump_should_return_401_for_unauthorized_user()
-            throws IOException, InterruptedException {
+        public void test_post_sorted_graph_dump_should_return_401_for_unauthorized_user() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -587,8 +578,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_sorted_graph_dump_should_return_403_for_forbidden_mask()
-            throws IOException, InterruptedException {
+        public void test_post_sorted_graph_dump_should_return_403_for_forbidden_mask() {
             // Given
             neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
@@ -620,8 +610,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_admin_neo4j_csvs_should_return_200()
-            throws IOException, InterruptedException {
+        public void test_post_admin_neo4j_csvs_should_return_200() throws IOException {
             // Given
             Path exportPath = null;
             byte[] exportContent = "exportbytescompressedintoatargz".getBytes();
@@ -683,8 +672,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_post_admin_neo4j_csvs_should_return_200()
-            throws IOException, InterruptedException {
+        public void test_post_admin_neo4j_csvs_should_return_200() throws IOException {
             // Given
             Path exportPath = null;
             byte[] exportContent = "exportbytescompressedintoatargz".getBytes();

--- a/src/test/java/org/icij/datashare/ObjectsTest.java
+++ b/src/test/java/org/icij/datashare/ObjectsTest.java
@@ -93,9 +93,11 @@ public class ObjectsTest {
                 // match
                 Neo4jUtils.PatternNode node0 =
                     new Neo4jUtils.PatternNode("doc", List.of("Document", "Important"),
-                        new HashMap<>() {{
-                            put("created", "someDate");
-                        }});
+                        new HashMap<>() {
+                            {
+                                put("created", "someDate");
+                            }
+                        });
                 Neo4jUtils.PatternNode node1 =
                     new Neo4jUtils.PatternNode("person", List.of("NamedEntity", "Person"), null);
                 Neo4jUtils.PatternRelationship rel =
@@ -149,8 +151,10 @@ public class ObjectsTest {
 
                 // Then
                 String expected =
-                    "MATCH (doc:`Document`:`Important` {created: 'someDate'})<-[rel:`APPEARS_IN`]-(person:`NamedEntity`:`Person`) "
-                        + "WHERE (doc.path STARTS WITH 'some/path/prefix' AND person.docId = doc.id) "
+                    "MATCH (doc:`Document`:`Important` {created: 'someDate'})"
+                        + "<-[rel:`APPEARS_IN`]-(person:`NamedEntity`:`Person`) "
+                        + "WHERE (doc.path STARTS WITH 'some/path/prefix'"
+                        + " AND person.docId = doc.id) "
                         + "RETURN * "
                         + "ORDER BY doc.path DESC "
                         + "LIMIT 100";


### PR DESCRIPTION
# PR description

Harmonize error handling in order to:
- log normalized messages
- return normalized HTTP errors
- avoid returning traces containing potential logs in http responses

# Changes

## `datashare-neo4j-extension/src`
### Changed
- udpated `HttpError` to avoid deserializing the `trace` attribute, this way no trace information  will be returned by the HTTP. In order to be able to log message with traces a `HttpError.getMessageWithTrace()`  method was added
- removed inheritance between `Neo4jAppError` and `HttpError` to isolate their behavior. `Neo4jAppError` represents a error returned by the Python application, it serialization had not reason to be bound to the `HttpError` serialization/deserialization
- improved Java error handling by catching error locally and throwing detailed `RuntimeError`
- refactored `wrapNeo4jAppCall` to reformat any unhandled exception into the `HttpError` using `HttpError.fromException` which converts any exception in a single format. The wrapper logs error with trace and return HTTP errors without traces
- refactored all API routes to be fully wrapped into the `wrapNeo4jAppCall`, the deserialization of the incoming payload is done using the `parseContext` function which raise a custom `BadRequest` error which it later caught and reformatted into the `HttpError`. This allows to return normalized errors in case of a `400` error rather than retuning  the non  formatted error from `fluent`


## `datashare-neo4j-extension/pom.xml`
### Fixed
- include test files in the files checked using `./neo4j format_test_java` and updated java files accordingly
