### PR TITLE
feature: robust ES search

### DIFF
--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -37,6 +37,8 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
     es_doc_type_field: str = Field(alias="docTypeField", default="type")
     es_default_page_size: int = 1000
     es_max_concurrency: int = 5
+    es_max_retries: int = 0
+    es_max_retry_wait_s: Union[int, float] = 60
     es_timeout_s: Union[int, float] = 60 * 5
     es_keep_alive: str = "1m"
     neo4j_app_host: str = "127.0.0.1"
@@ -149,6 +151,8 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
             pagination=self.es_default_page_size,
             max_concurrency=self.es_max_concurrency,
             timeout=self.es_timeout_s,
+            max_retries=self.es_max_retries,
+            max_retry_wait_s=self.es_max_retry_wait_s,
         )
         return client
 

--- a/neo4j-app/poetry.lock
+++ b/neo4j-app/poetry.lock
@@ -1361,6 +1361,20 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart", "pyyaml"]
 
 [[package]]
+name = "tenacity"
+version = "8.2.3"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
+    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -1839,4 +1853,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "54bd8bf9ca755d6b12c2165607753b2c4a23f6e5cfee7348f14e556e4e558204"
+content-hash = "432e72cf1cf2a4e478a8f530ad01b3066760ddef97aad418384f2d94727e19cf"

--- a/neo4j-app/pyproject.toml
+++ b/neo4j-app/pyproject.toml
@@ -22,6 +22,7 @@ elasticsearch = {version = "<7.14", extras = ["async"]}
 neo4j = "^5.5.0"
 setuptools = "^67.6.1"
 datrie = "^0.8.2"
+tenacity = "^8.2.3"
 
 [tool.poetry.group.dev.dependencies]
 fastapi = { version = "^0.99.1", extras = ["all"] }


### PR DESCRIPTION
# PR description

When polling from ES, `429 Too Many Requests` seems to be recurrent when the ES cluster is under (more or less) heavy load. In order to avoid failing the whole pipeline when this happens, the ES clients now retries the search after a random exponential backoff using [tenacity](https://tenacity.readthedocs.io/en/latest/)

# Changes
## `datashare-neo4j-extension/neo4j-app`
- Added the `ESClientABC._max_retries: int = 0` and `self._max_retry_wait_s = max_retry_wait_s` attributes to the `ESClientABC`. When calling `poll_search_pages`, in case of a `TransportError` with code `429`, the client will retry to fetch the data at most `_max_retries` times, sleeping between each attempt. The sleep duration will be a random duration between 0 and `min(2^retry_attempt, max_retry_wait_s)`
- Added the `AppConfig.es_max_retries: int = 0` and `AppConfig.es_max_retry_wait_s: Union[int, float] = 60` attributes to the config. These attributes are forwared to the ES client when building it
