### PR TITLE
chore: refactor neo4j enterprise support

### DIFF
--- a/neo4j-app/neo4j_app/app/admin.py
+++ b/neo4j-app/neo4j_app/app/admin.py
@@ -38,7 +38,6 @@ def admin_router() -> APIRouter:
     )
     async def _neo4j_csv(
         project: str,
-        index: str,
         payload: Neo4jCSVRequest,
         request: Request,
         es_client: ESClientABC = Depends(es_client_dep),
@@ -55,7 +54,6 @@ def admin_router() -> APIRouter:
                 export_dir=Path(tmpdir),
                 es_query=payload.query,
                 es_client=es_client,
-                es_index=index,
                 es_concurrency=config.es_max_concurrency,
                 es_keep_alive=config.es_keep_alive,
                 es_doc_type_field=config.es_doc_type_field,

--- a/neo4j-app/neo4j_app/app/doc.py
+++ b/neo4j-app/neo4j_app/app/doc.py
@@ -3,6 +3,7 @@ DOCUMENT_TAG = "Documents"
 NE_TAG = "Named entities"
 OTHER_TAG = "Other"
 GRAPH_TAG = "Graphs"
+PROJECT_TAG = "Project"
 
 
 DOC_IMPORT_SUM = "Import documents from elasticsearch to neo4j"
@@ -175,3 +176,8 @@ and then the query which will actually be performed will be:
 The `<docFieldType>` defaults to `type` and is supposed to be forwarded from the Java \
 app to the Python one through configuration. 
 """
+
+DOC_PROJECT_INIT = (
+    "Initializes the app for the provided project (creates and migrate"
+    " the associated neo4j DB)"
+)

--- a/neo4j-app/neo4j_app/app/documents.py
+++ b/neo4j-app/neo4j_app/app/documents.py
@@ -28,7 +28,6 @@ def documents_router() -> APIRouter:
     )
     async def _import_documents(
         project: str,
-        index: str,
         payload: IncrementalImportRequest,
         request: Request,
         neo4j_driver: neo4j.AsyncDriver = Depends(neo4j_driver_dep),
@@ -41,7 +40,6 @@ def documents_router() -> APIRouter:
             res = await import_documents(
                 project=project,
                 es_client=es_client,
-                es_index=index,
                 es_query=payload.query,
                 es_concurrency=es_client.max_concurrency,
                 es_keep_alive=config.es_keep_alive,

--- a/neo4j-app/neo4j_app/app/documents.py
+++ b/neo4j-app/neo4j_app/app/documents.py
@@ -27,7 +27,7 @@ def documents_router() -> APIRouter:
         description=DOC_IMPORT_DESC,
     )
     async def _import_documents(
-        database: str,
+        project: str,
         index: str,
         payload: IncrementalImportRequest,
         request: Request,
@@ -39,6 +39,7 @@ def documents_router() -> APIRouter:
             logger, logging.INFO, "Imported documents in {elapsed_time} !"
         ):
             res = await import_documents(
+                project=project,
                 es_client=es_client,
                 es_index=index,
                 es_query=payload.query,
@@ -46,7 +47,6 @@ def documents_router() -> APIRouter:
                 es_keep_alive=config.es_keep_alive,
                 es_doc_type_field=config.es_doc_type_field,
                 neo4j_driver=neo4j_driver,
-                neo4j_db=database,
                 neo4j_import_batch_size=config.neo4j_import_batch_size,
                 neo4j_transaction_batch_size=config.neo4j_transaction_batch_size,
                 max_records_in_memory=config.neo4j_app_max_records_in_memory,

--- a/neo4j-app/neo4j_app/app/graphs.py
+++ b/neo4j-app/neo4j_app/app/graphs.py
@@ -23,7 +23,7 @@ def graphs_router() -> APIRouter:
         description=DOC_GRAPH_DUMP_DESC,
     )
     async def _graph_dump(
-        database: str,
+        project: str,
         payload: DumpRequest,
         neo4j_driver: neo4j.AsyncDriver = Depends(neo4j_driver_dep),
     ) -> StreamingResponse:
@@ -32,9 +32,9 @@ def graphs_router() -> APIRouter:
         ):
             res = StreamingResponse(
                 dump_graph(
+                    project=project,
                     dump_format=payload.format,
                     neo4j_driver=neo4j_driver,
-                    neo4j_db=database,
                     query=payload.query,
                 ),
                 media_type="binary/octet-stream",

--- a/neo4j-app/neo4j_app/app/named_entities.py
+++ b/neo4j-app/neo4j_app/app/named_entities.py
@@ -28,7 +28,6 @@ def named_entities_router() -> APIRouter:
     )
     async def _import_named_entities(
         project: str,
-        index: str,
         payload: IncrementalImportRequest,
         request: Request,
         neo4j_driver: neo4j.AsyncDriver = Depends(neo4j_driver_dep),
@@ -41,7 +40,6 @@ def named_entities_router() -> APIRouter:
             res = await import_named_entities(
                 project=project,
                 es_client=es_client,
-                es_index=index,
                 es_query=payload.query,
                 es_concurrency=es_client.max_concurrency,
                 es_keep_alive=config.es_keep_alive,

--- a/neo4j-app/neo4j_app/app/named_entities.py
+++ b/neo4j-app/neo4j_app/app/named_entities.py
@@ -27,7 +27,7 @@ def named_entities_router() -> APIRouter:
         description=NE_IMPORT_DESC,
     )
     async def _import_named_entities(
-        database: str,
+        project: str,
         index: str,
         payload: IncrementalImportRequest,
         request: Request,
@@ -39,13 +39,13 @@ def named_entities_router() -> APIRouter:
             logger, logging.INFO, "Imported named entities in {elapsed_time} !"
         ):
             res = await import_named_entities(
+                project=project,
                 es_client=es_client,
                 es_index=index,
                 es_query=payload.query,
                 es_concurrency=es_client.max_concurrency,
                 es_keep_alive=config.es_keep_alive,
                 es_doc_type_field=config.es_doc_type_field,
-                neo4j_db=database,
                 neo4j_driver=neo4j_driver,
                 neo4j_import_batch_size=config.neo4j_import_batch_size,
                 neo4j_transaction_batch_size=config.neo4j_transaction_batch_size,

--- a/neo4j-app/neo4j_app/app/projects.py
+++ b/neo4j-app/neo4j_app/app/projects.py
@@ -1,0 +1,41 @@
+import logging
+
+import neo4j
+from fastapi import APIRouter, Depends
+from starlette.responses import Response
+
+from neo4j_app.app.dependencies import get_global_config_dep, neo4j_driver_dep
+from neo4j_app.app.doc import (
+    DOC_PROJECT_INIT,
+    PROJECT_TAG,
+)
+from neo4j_app.core import AppConfig
+from neo4j_app.core.neo4j import MIGRATIONS
+from neo4j_app.core.neo4j.migrations.migrate import init_project
+
+logger = logging.getLogger(__name__)
+
+
+def projects_router() -> APIRouter:
+    router = APIRouter(prefix="/projects", tags=[PROJECT_TAG])
+
+    @router.post(
+        "/init",
+        summary=DOC_PROJECT_INIT,
+    )
+    async def _init_project(
+        project: str,
+        config: AppConfig = Depends(get_global_config_dep),
+        neo4j_driver: neo4j.AsyncDriver = Depends(neo4j_driver_dep),
+    ):
+        existed = await init_project(
+            neo4j_driver=neo4j_driver,
+            name=project,
+            registry=MIGRATIONS,
+            timeout_s=config.neo4j_app_migration_timeout_s,
+            throttle_s=config.neo4j_app_migration_throttle_s,
+        )
+        status_code = 200 if existed else 201
+        return Response(status_code=status_code)
+
+    return router

--- a/neo4j-app/neo4j_app/app/utils.py
+++ b/neo4j-app/neo4j_app/app/utils.py
@@ -18,6 +18,7 @@ from neo4j_app.app.documents import documents_router
 from neo4j_app.app.graphs import graphs_router
 from neo4j_app.app.main import main_router
 from neo4j_app.app.named_entities import named_entities_router
+from neo4j_app.app.projects import projects_router
 from neo4j_app.core import AppConfig
 from neo4j_app.core.neo4j import MIGRATIONS, migrate_db_schemas
 from neo4j_app.core.neo4j.migrations import delete_all_migrations
@@ -96,7 +97,7 @@ def create_app(config: AppConfig) -> FastAPI:
     app.add_exception_handler(StarletteHTTPException, http_exception_handler)
     app.add_exception_handler(Exception, internal_exception_handler)
     app.add_event_handler("startup", app.state.config.setup_loggers)
-    # This one is not a migration, migrations run on project DBs, this one runs on a
+    # This one is not a migration, migrations run on project DBs, it runs on a
     # utility DB
     app.add_event_handler(
         "startup", functools.partial(create_project_registry_db_, app)
@@ -107,6 +108,7 @@ def create_app(config: AppConfig) -> FastAPI:
     app.include_router(named_entities_router())
     app.include_router(admin_router())
     app.include_router(graphs_router())
+    app.include_router(projects_router())
     return app
 
 

--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -1,5 +1,7 @@
 from neo4j_app.core.elasticsearch.utils import JOIN
 
+PROJECT_REGISTRY_DB = "datashare-project-registry"
+
 NEO4J_CSV_COL = "node_col"
 
 # TODO: replicate other doc attributes
@@ -24,13 +26,18 @@ DOC_COLUMNS = {
 
 DOC_ES_SOURCES = list(DOC_COLUMNS) + [JOIN, DOC_ROOT_ID]
 
+PROJECT_RUNS_MIGRATION = "_RUNS"
+PROJECT_NAME = "name"
+PROJECT_NODE = "_Project"
 
 MIGRATION_COMPLETED = "completed"
 MIGRATION_LABEL = "label"
-MIGRATION_NODE = "Migration"
+MIGRATION_NODE = "_Migration"
+MIGRATION_PROJECT = "project"
 MIGRATION_STARTED = "started"
 MIGRATION_STATUS = "status"
 MIGRATION_VERSION = "version"
+
 
 # TODO: replicate other named entities attributes
 NE_APPEARS_IN_DOC = "APPEARS_IN"

--- a/neo4j-app/neo4j_app/core/config.py
+++ b/neo4j-app/neo4j_app/core/config.py
@@ -166,10 +166,12 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
             uvicorn.__name__,
             elasticsearch.__name__,
         ]
+        force_info = {elasticsearch.__name__}
         try:
             import opensearchpy
 
             loggers.append(opensearchpy.__name__)
+            force_info.add(opensearchpy.__name__)
         except ImportError:
             pass
 
@@ -179,7 +181,7 @@ class AppConfig(LowerCamelCaseModel, IgnoreExtraModel):
         for logger in loggers:
             logger = logging.getLogger(logger)
             level = getattr(logging, self.neo4j_app_log_level)
-            if logger == elasticsearch.__name__:
+            if logger in force_info:
                 level = max(logging.INFO, level)
             logger.setLevel(level)
             logger.handlers = []

--- a/neo4j-app/neo4j_app/core/imports.py
+++ b/neo4j-app/neo4j_app/core/imports.py
@@ -204,6 +204,7 @@ async def import_named_entities(
     # Since this is an incremental import we consider it reasonable to use an ES join,
     # however for named entities bulk import join should be avoided and post filtering
     # on the documentId will probably be much more efficient !
+
     # TODO: if joining is too slow, switch to post filtering
     # TODO: project document fields here in order to reduce the ES payloads...
     async with es_client.try_open_pit(index=es_index, keep_alive=es_keep_alive) as pit:

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -8,28 +8,19 @@ from typing import Dict, Iterable, List, Optional, TextIO, Tuple
 from .imports import Neo4Import, Neo4jImportWorker
 from .migrations import Migration
 from .migrations.migrate import MigrationError, migrate_db_schemas
-from .migrations.migrations import (
-    create_document_and_ne_id_unique_constraint_tx,
-    create_migration_unique_constraint_tx,
-    replace_ne_constraint_on_id_by_index_on_mention_norm_tx,
-)
+from .migrations.migrations import migration_v_0_1_0_tx, migration_v_0_2_0_tx
 
-FIRST_MIGRATION = Migration(
+V_0_1_0 = Migration(
     version="0.1.0",
-    label="Create migration index and constraints",
-    migration_fn=create_migration_unique_constraint_tx,
+    label="Create migration and project and constraints",
+    migration_fn=migration_v_0_1_0_tx,
 )
-V_O_2_0 = Migration(
+V_0_2_0 = Migration(
     version="0.2.0",
-    label="Add uniqueness constraint for documents and named entities",
-    migration_fn=create_document_and_ne_id_unique_constraint_tx,
+    label="Create doc and named entities index and constraints",
+    migration_fn=migration_v_0_2_0_tx,
 )
-V_O_3_0 = Migration(
-    version="0.3.0",
-    label="Replace named entity unique ID constraint by index on mention norm",
-    migration_fn=replace_ne_constraint_on_id_by_index_on_mention_norm_tx,
-)
-MIGRATIONS = [FIRST_MIGRATION, V_O_2_0, V_O_3_0]
+MIGRATIONS = [V_0_1_0, V_0_2_0]
 
 
 def get_neo4j_csv_reader(

--- a/neo4j-app/neo4j_app/core/neo4j/dumps.py
+++ b/neo4j-app/neo4j_app/core/neo4j/dumps.py
@@ -3,6 +3,7 @@ from typing import AsyncGenerator, Optional
 import neo4j
 
 from neo4j_app.constants import MIGRATION_NODE
+from neo4j_app.core.neo4j.projects import project_db
 from neo4j_app.core.objects import DumpFormat
 
 _GRAPHML_DUMP_CONFIG = {
@@ -30,12 +31,13 @@ RETURN d, r, other
 
 
 async def dump_graph(
+    project: str,
     dump_format: DumpFormat,
     neo4j_driver: neo4j.AsyncDriver,
-    neo4j_db: str,
     query: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
     # TODO: support batchsize ?
+    neo4j_db = await project_db(neo4j_driver, project)
     if query is None:
         query = _DEFAULT_DUMP_QUERY
     if dump_format is DumpFormat.GRAPHML:

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -20,7 +20,6 @@ from neo4j_app.constants import (
     MIGRATION_STARTED,
     MIGRATION_STATUS,
     MIGRATION_VERSION,
-    PROJECT_REGISTRY_DB,
 )
 from neo4j_app.core.neo4j.projects import (
     Project,

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -121,7 +121,7 @@ async def _migrate_with_lock(
     await project_session.execute_write(migration.migration_fn)
     # Finally free the lock
     await registry_session.execute_write(
-        complete_migration_run_tx,
+        complete_migration_tx,
         project=project,
         migration_version=str(migration.version),
     )
@@ -158,7 +158,7 @@ RETURN m as migration"""
     return migration
 
 
-async def complete_migration_run_tx(
+async def complete_migration_tx(
     tx: neo4j.AsyncTransaction, *, project: str, migration_version: str
 ) -> Neo4jMigration:
     query = f"""MATCH (m:{MIGRATION_NODE} {{

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -16,17 +16,23 @@ from neo4j_app.constants import (
     MIGRATION_COMPLETED,
     MIGRATION_LABEL,
     MIGRATION_NODE,
+    MIGRATION_PROJECT,
     MIGRATION_STARTED,
     MIGRATION_STATUS,
     MIGRATION_VERSION,
+    PROJECT_REGISTRY_DB,
+)
+from neo4j_app.core.neo4j.projects import (
+    Project,
+    create_project_tx,
+    project_db_session,
+    registry_db_session,
 )
 from neo4j_app.core.utils.pydantic import NoEnumModel
 
 logger = logging.getLogger(__name__)
 
 MigrationFn = Callable[[neo4j.AsyncTransaction], Coroutine]
-
-_NEO4J_SYSTEM_DB = "system"
 
 _MIGRATION_TIMEOUT_MSG = """Migration timeout expired !
 Please check that a migration is indeed in progress. If the application is in a \
@@ -64,10 +70,16 @@ class _BaseMigration(NoEnumModel):
 
 
 class Neo4jMigration(_BaseMigration):
-    version: MigrationVersion
-    label: str
+    # It would have been cleaner to create
+    # (p:_Project)-[:_RUNS { id: p.name + m.version }]->(m:_Migration)
+    # relationships. However, neo4j < 5.7 doesn't support unique constraint on
+    # relationships properties which prevents from implementing the locking mechanism
+    # properly. We hence enforce unique constraint on
+    # (_Migration.version, _Migration.project)
+    project: str
     started: datetime
     completed: Optional[datetime] = None
+    status: MigrationStatus = MigrationStatus.IN_PROGRESS
 
     @classmethod
     def from_neo4j(cls, record: neo4j.Record, key="migration") -> Neo4jMigration:
@@ -86,23 +98,32 @@ class Migration(_BaseMigration):
 MigrationRegistry: Sequence[Migration]
 
 
-async def _migration_wrapper(neo4j_session: neo4j.AsyncSession, migration: Migration):
-    # Note: all migrations.py should be carefully test otherwise they will lock
+async def _migrate_with_lock(
+    *,
+    project_session: neo4j.AsyncSession,
+    registry_session: neo4j.AsyncSession,
+    project: str,
+    migration: Migration,
+):
+    # Note: all migrations.py should be carefully tested otherwise they will lock
     # the DB...
 
     # Lock the DB first, raising in case a migration already exists
     logger.debug("Trying to run migration %s...", migration.label)
-    await neo4j_session.execute_write(
+    await registry_session.execute_write(
         create_migration_tx,
+        project=project,
         migration_version=str(migration.version),
         migration_label=migration.label,
     )
     # Then run to migration
     logger.debug("Acquired write lock for %s !", migration.label)
-    await neo4j_session.execute_write(migration.migration_fn)
+    await project_session.execute_write(migration.migration_fn)
     # Finally free the lock
-    await neo4j_session.execute_write(
-        complete_migration_tx, version=str(migration.version)
+    await registry_session.execute_write(
+        complete_migration_run_tx,
+        project=project,
+        migration_version=str(migration.version),
     )
     logger.debug("Marked %s as complete !", migration.label)
 
@@ -110,10 +131,12 @@ async def _migration_wrapper(neo4j_session: neo4j.AsyncSession, migration: Migra
 async def create_migration_tx(
     tx: neo4j.AsyncTransaction,
     *,
+    project: str,
     migration_version: str,
     migration_label: str,
 ) -> Neo4jMigration:
     query = f"""CREATE (m:{MIGRATION_NODE} {{
+    {MIGRATION_PROJECT}: $project,
     {MIGRATION_LABEL}: $label,
     {MIGRATION_VERSION}: $version,
     {MIGRATION_STATUS}: $status,
@@ -124,37 +147,46 @@ RETURN m as migration"""
         query,
         label=migration_label,
         version=migration_version,
+        project=project,
         status=MigrationStatus.IN_PROGRESS.value,
         started=datetime.now(),
     )
-    m = await res.single()
-    m = Neo4jMigration.from_neo4j(m, key="migration")
-    return m
+    migration = await res.single()
+    if migration is None:
+        raise ValueError(f"Couldn't find migration {migration_version} for {project}")
+    migration = Neo4jMigration.from_neo4j(migration)
+    return migration
 
 
-async def complete_migration_tx(
-    tx: neo4j.AsyncTransaction, version: str
+async def complete_migration_run_tx(
+    tx: neo4j.AsyncTransaction, *, project: str, migration_version: str
 ) -> Neo4jMigration:
-    query = f"""MATCH (m:{MIGRATION_NODE} {{ {MIGRATION_VERSION}: $version }})
+    query = f"""MATCH (m:{MIGRATION_NODE} {{
+        {MIGRATION_VERSION}: $version,
+        {MIGRATION_PROJECT}: $project
+     }})
 SET m += {{ {MIGRATION_STATUS}: $status, {MIGRATION_COMPLETED}: $completed }} 
 RETURN m as migration"""
     res = await tx.run(
         query,
-        version=version,
+        version=migration_version,
+        project=project,
         status=MigrationStatus.DONE.value,
         completed=datetime.now(),
     )
-    m = await res.single()
-    m = Neo4jMigration.from_neo4j(m, key="migration")
-    return m
+    migration = await res.single()
+    migration = Neo4jMigration.from_neo4j(migration)
+    return migration
 
 
-async def migrations_tx(tx: neo4j.AsyncTransaction) -> List[Neo4jMigration]:
-    query = f"""MATCH (m:{MIGRATION_NODE})
+async def project_migrations_tx(
+    tx: neo4j.AsyncTransaction, project: str
+) -> List[Neo4jMigration]:
+    query = f"""MATCH (m:{MIGRATION_NODE} {{ {MIGRATION_PROJECT}: $project }})
 RETURN m as migration
 """
-    res = await tx.run(query)
-    migrations = [Neo4jMigration.from_neo4j(rec, key="migration") async for rec in res]
+    res = await tx.run(query, project=project)
+    migrations = [Neo4jMigration.from_neo4j(rec) async for rec in res]
     return migrations
 
 
@@ -165,14 +197,12 @@ DETACH DELETE m
     await driver.execute_query(query)
 
 
-async def retrieve_project_dbs(neo4j_driver: neo4j.AsyncDriver) -> List[str]:
-    query = f"""SHOW DATABASES YIELD name, currentStatus
-WHERE currentStatus = "online" and name <> "{_NEO4J_SYSTEM_DB}"
-RETURN name
-"""
-    records, _, _ = await neo4j_driver.execute_query(query)
-    project_dbs = [rec["name"] for rec in records]
-    return project_dbs
+async def retrieve_projects(neo4j_driver: neo4j.AsyncDriver) -> List[Project]:
+    async with registry_db_session(neo4j_driver) as sess:
+        from neo4j_app.core.neo4j.projects import projects_tx
+
+        projects = await sess.execute_read(projects_tx)
+    return projects
 
 
 async def migrate_db_schemas(
@@ -182,70 +212,106 @@ async def migrate_db_schemas(
     timeout_s: float,
     throttle_s: float,
 ):
-    project_dbs = await retrieve_project_dbs(neo4j_driver)
+    projects = await retrieve_projects(neo4j_driver)
     tasks = [
         migrate_project_db_schema(
-            neo4j_driver, registry, db=db, timeout_s=timeout_s, throttle_s=throttle_s
+            neo4j_driver,
+            registry,
+            project=p.name,
+            timeout_s=timeout_s,
+            throttle_s=throttle_s,
         )
-        for db in project_dbs
+        for p in projects
     ]
     await asyncio.gather(*tasks)
-
-
-# Retrieve all project DBs
 
 
 async def migrate_project_db_schema(
     neo4j_driver: neo4j.AsyncDriver,
     registry: MigrationRegistry,
-    db: str,
+    project: str,
     *,
     timeout_s: float,
     throttle_s: float,
 ):
-    logger.info("Migrating project DB %s", db)
+    logger.info("Migrating project project %s", project)
     start = time.monotonic()
     if not registry:
         return
     todo = sorted(registry, key=lambda m: m.version)
-    async with neo4j_driver.session(database=db) as sess:
-        while "Waiting for DB to be migrated or for a timeout":
-            elapsed = time.monotonic() - start
-            if elapsed > timeout_s:
-                logger.error(_MIGRATION_TIMEOUT_MSG)
-                raise MigrationError(_MIGRATION_TIMEOUT_MSG)
-            migrations = await sess.execute_read(migrations_tx)
-            in_progress = [
-                m for m in migrations if m.status is MigrationStatus.IN_PROGRESS
-            ]
-            if len(in_progress) > 1:
-                raise MigrationError(
-                    f"Found several migration in progress: {in_progress}"
+    async with registry_db_session(neo4j_driver) as registry_sess:
+        async with project_db_session(neo4j_driver, project=project) as project_sess:
+            while "Waiting for DB to be migrated or for a timeout":
+                elapsed = time.monotonic() - start
+                if elapsed > timeout_s:
+                    logger.error(_MIGRATION_TIMEOUT_MSG)
+                    raise MigrationError(_MIGRATION_TIMEOUT_MSG)
+                migrations = await project_sess.execute_read(
+                    project_migrations_tx, project=project
                 )
-            if in_progress:
-                logger.info(
-                    "Found that %s is in progress, waiting for %s seconds...",
-                    in_progress[0].label,
-                    throttle_s,
-                )
-                await asyncio.sleep(throttle_s)
-                continue
-            done = [m for m in migrations if m.status is MigrationStatus.DONE]
-            if done:
-                current_version = max((m.version for m in done))
-                todo = [m for m in todo if m.version > current_version]
-            if not todo:
-                break
-            try:
-                await _migration_wrapper(sess, todo[0])
-                todo = todo[1:]
-                continue
-            except ConstraintError:
-                logger.info(
-                    "Migration %s has just started somewhere else, "
-                    " waiting for %s seconds...",
-                    todo[0].label,
-                    throttle_s,
-                )
-                await asyncio.sleep(throttle_s)
-                continue
+                in_progress = [
+                    m for m in migrations if m.status is MigrationStatus.IN_PROGRESS
+                ]
+                if len(in_progress) > 1:
+                    raise MigrationError(
+                        f"Found several migration in progress: {in_progress}"
+                    )
+                if in_progress:
+                    logger.info(
+                        "Found that %s is in progress, waiting for %s seconds...",
+                        in_progress[0].label,
+                        throttle_s,
+                    )
+                    await asyncio.sleep(throttle_s)
+                    continue
+                done = [m for m in migrations if m.status is MigrationStatus.DONE]
+                if done:
+                    current_version = max((m.version for m in done))
+                    todo = [m for m in todo if m.version > current_version]
+                if not todo:
+                    break
+                try:
+                    await _migrate_with_lock(
+                        project_session=project_sess,
+                        registry_session=registry_sess,
+                        project=project,
+                        migration=todo[0],
+                    )
+                    todo = todo[1:]
+                    continue
+                except ConstraintError:
+                    logger.info(
+                        "Migration %s has just started somewhere else, "
+                        " waiting for %s seconds...",
+                        todo[0].label,
+                        throttle_s,
+                    )
+                    await asyncio.sleep(throttle_s)
+                    continue
+
+
+async def init_project(
+    driver: neo4j.AsyncDriver,
+    name: str,
+    registry: MigrationRegistry,
+    *,
+    timeout_s: float,
+    throttle_s: float,
+):
+    if name == PROJECT_REGISTRY_DB:
+        raise ValueError(
+            f'Bad luck, name "{PROJECT_REGISTRY_DB}" is reserved for internal use.'
+            f" Can't initialize project"
+        )
+    # Create project
+    async with registry_db_session(driver) as sess:
+        project = await sess.execute_write(create_project_tx, name=name)
+
+    # Migrate it
+    await migrate_project_db_schema(
+        driver,
+        registry=registry,
+        project=project.name,
+        timeout_s=timeout_s,
+        throttle_s=throttle_s,
+    )

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -298,11 +298,6 @@ async def init_project(
     timeout_s: float,
     throttle_s: float,
 ):
-    if name == PROJECT_REGISTRY_DB:
-        raise ValueError(
-            f'Bad luck, name "{PROJECT_REGISTRY_DB}" is reserved for internal use.'
-            f" Can't initialize project"
-        )
     # Create project
     async with registry_db_session(driver) as sess:
         project = await sess.execute_write(create_project_tx, name=name)

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
@@ -4,23 +4,27 @@ from neo4j_app.constants import (
     DOC_ID,
     DOC_NODE,
     MIGRATION_NODE,
+    MIGRATION_PROJECT,
     MIGRATION_VERSION,
     NE_ID,
     NE_MENTION_NORM,
     NE_NODE,
+    PROJECT_NAME,
+    PROJECT_NODE,
 )
 
 
-async def create_migration_unique_constraint_tx(tx: neo4j.AsyncTransaction):
-    constraint_query = f"""CREATE CONSTRAINT constraint_migration_unique_version
-IF NOT EXISTS 
-FOR (m:{MIGRATION_NODE})
-REQUIRE (m.{MIGRATION_VERSION}) IS UNIQUE
-"""
-    await tx.run(constraint_query)
+async def migration_v_0_1_0_tx(tx: neo4j.AsyncTransaction):
+    await _create_project_unique_name_constraint_tx(tx)
+    await _create_migration_unique_project_and_version_constraint_tx(tx)
 
 
-async def create_document_and_ne_id_unique_constraint_tx(tx: neo4j.AsyncTransaction):
+async def migration_v_0_2_0_tx(tx: neo4j.AsyncTransaction):
+    await _create_document_and_ne_id_unique_constraint_tx(tx)
+    await _create_ne_mention_norm_index_tx(tx)
+
+
+async def _create_document_and_ne_id_unique_constraint_tx(tx: neo4j.AsyncTransaction):
     doc_query = f"""CREATE CONSTRAINT constraint_document_unique_id
 IF NOT EXISTS 
 FOR (doc:{DOC_NODE})
@@ -35,15 +39,33 @@ REQUIRE (ent.{NE_ID}) IS UNIQUE
     await tx.run(ne_query)
 
 
-async def replace_ne_constraint_on_id_by_index_on_mention_norm_tx(
+async def _create_ne_mention_norm_index_tx(
     tx: neo4j.AsyncTransaction,
 ):
-    delete_constraint_on_id = """DROP CONSTRAINT constraint_named_entity_unique_id
-IF EXISTS"""
-    await tx.run(delete_constraint_on_id)
-    create_constraint_on_mention_norm = f"""
+    create_index_on_mention_norm = f"""
 CREATE INDEX index_ne_mention_norm IF NOT EXISTS
 FOR (ent:{NE_NODE})
 ON (ent.{NE_MENTION_NORM})
 """
-    await tx.run(create_constraint_on_mention_norm)
+    await tx.run(create_index_on_mention_norm)
+
+
+async def _create_project_unique_name_constraint_tx(tx: neo4j.AsyncTransaction):
+    constraint_query = f"""CREATE CONSTRAINT constraint_project_unique_name
+IF NOT EXISTS
+FOR (p:{PROJECT_NODE})
+REQUIRE (p.{PROJECT_NAME}) IS UNIQUE
+"""
+    await tx.run(constraint_query)
+
+
+async def _create_migration_unique_project_and_version_constraint_tx(
+    tx: neo4j.AsyncTransaction,
+):
+    constraint_query = f"""CREATE CONSTRAINT
+     constraint_migration_unique_project_and_version
+IF NOT EXISTS 
+FOR (m:{MIGRATION_NODE})
+REQUIRE (m.{MIGRATION_VERSION}, m.{MIGRATION_PROJECT}) IS UNIQUE
+"""
+    await tx.run(constraint_query)

--- a/neo4j-app/neo4j_app/core/neo4j/projects.py
+++ b/neo4j-app/neo4j_app/core/neo4j/projects.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+import logging
+from contextlib import asynccontextmanager
+from typing import List
+
+import neo4j
+
+from neo4j_app.constants import PROJECT_NAME, PROJECT_NODE, PROJECT_REGISTRY_DB
+from neo4j_app.core.utils.pydantic import BaseICIJModel
+
+logger = logging.getLogger(__name__)
+
+NEO4J_COMMUNITY_DB = "neo4j"
+_IS_ENTERPRISE = None
+
+
+class Project(BaseICIJModel):
+    name: str
+
+    @classmethod
+    def from_neo4j(cls, record: neo4j.Record, key="project") -> Project:
+        project = dict(record[key])
+        return Project(**project)
+
+
+async def create_project_registry_db(neo4j_driver: neo4j.AsyncDriver):
+    async with neo4j_driver:
+        if await is_enterprise(neo4j_driver):
+            logger.info("Creating project registry DB...")
+            query = "CREATE DATABASE $registry_db IF NOT EXISTS"
+            await neo4j_driver.execute_query(query, registry_db=PROJECT_REGISTRY_DB)
+        else:
+            logger.info("Using default db as registry DB !")
+
+
+async def projects_tx(tx: neo4j.AsyncTransaction) -> List[Project]:
+    query = f"MATCH (project:{PROJECT_NODE}) RETURN project"
+    res = await tx.run(query)
+    projects = [Project.from_neo4j(p) async for p in res]
+    return projects
+
+
+async def create_project_tx(tx: neo4j.AsyncTransaction, name: str) -> Project:
+    query = f"""MERGE (project:{PROJECT_NODE} {{ {PROJECT_NAME}: $name }})
+RETURN project"""
+    res = await tx.run(query, name=name)
+    project = Project.from_neo4j(await res.single())
+    return project
+
+
+async def project_registry_db(neo4j_driver: neo4j.AsyncDriver) -> str:
+    if await is_enterprise(neo4j_driver):
+        return PROJECT_REGISTRY_DB
+    return NEO4J_COMMUNITY_DB
+
+
+async def project_db(neo4j_driver: neo4j.AsyncDriver, project: str):
+    if await is_enterprise(neo4j_driver):
+        return project
+    return NEO4J_COMMUNITY_DB
+
+
+@asynccontextmanager
+async def project_db_session(
+    neo4j_driver: neo4j.AsyncDriver, project: str
+) -> neo4j.AsyncSession:
+    db = await project_db(neo4j_driver, project)
+    sess_ctx = neo4j_driver.session(database=db)
+    async with sess_ctx as sess:
+        yield sess
+
+
+@asynccontextmanager
+async def registry_db_session(neo4j_driver: neo4j.AsyncDriver) -> neo4j.AsyncSession:
+    session = neo4j_driver.session(database=await project_registry_db(neo4j_driver))
+    async with session as sess:
+        yield sess
+
+
+async def is_enterprise(neo4j_driver: neo4j.AsyncDriver) -> bool:
+    global _IS_ENTERPRISE
+    if _IS_ENTERPRISE is None:
+        query = "CALL dbms.components() YIELD edition RETURN edition"
+        res, _, _ = await neo4j_driver.execute_query(query)
+        _IS_ENTERPRISE = res[0]["edition"] != "community"
+    return _IS_ENTERPRISE

--- a/neo4j-app/neo4j_app/core/neo4j/projects.py
+++ b/neo4j-app/neo4j_app/core/neo4j/projects.py
@@ -59,10 +59,14 @@ async def project_registry_db(neo4j_driver: neo4j.AsyncDriver) -> str:
     return NEO4J_COMMUNITY_DB
 
 
-async def project_db(neo4j_driver: neo4j.AsyncDriver, project: str):
+async def project_db(neo4j_driver: neo4j.AsyncDriver, project: str) -> str:
     if await is_enterprise(neo4j_driver):
         return project
     return NEO4J_COMMUNITY_DB
+
+
+def project_index(project: str) -> str:
+    return project
 
 
 @asynccontextmanager

--- a/neo4j-app/neo4j_app/core/neo4j/projects.py
+++ b/neo4j-app/neo4j_app/core/neo4j/projects.py
@@ -41,6 +41,11 @@ async def projects_tx(tx: neo4j.AsyncTransaction) -> List[Project]:
 
 
 async def create_project_tx(tx: neo4j.AsyncTransaction, name: str) -> Project:
+    if name == PROJECT_REGISTRY_DB:
+        raise ValueError(
+            f'Bad luck, name "{PROJECT_REGISTRY_DB}" is reserved for internal use.'
+            f" Can't initialize project"
+        )
     query = f"""MERGE (project:{PROJECT_NODE} {{ {PROJECT_NAME}: $name }})
 RETURN project"""
     res = await tx.run(query, name=name)

--- a/neo4j-app/neo4j_app/core/neo4j/projects.py
+++ b/neo4j-app/neo4j_app/core/neo4j/projects.py
@@ -103,5 +103,7 @@ async def is_enterprise(neo4j_driver: neo4j.AsyncDriver) -> bool:
     if _IS_ENTERPRISE is None:
         query = "CALL dbms.components() YIELD edition RETURN edition"
         res, _, _ = await neo4j_driver.execute_query(query)
+        if not res:
+            raise ValueError("Failed to determine neo4j distribution")
         _IS_ENTERPRISE = res[0]["edition"] != "community"
     return _IS_ENTERPRISE

--- a/neo4j-app/neo4j_app/core/utils/pydantic.py
+++ b/neo4j-app/neo4j_app/core/utils/pydantic.py
@@ -37,6 +37,6 @@ class IgnoreExtraModel(BaseICIJModel):
         extra = "ignore"
 
 
-class NoEnumModel(BaseModel):
+class NoEnumModel(BaseICIJModel):
     class Config:
         use_enum_values = False

--- a/neo4j-app/neo4j_app/core/utils/pydantic.py
+++ b/neo4j-app/neo4j_app/core/utils/pydantic.py
@@ -10,6 +10,20 @@ def to_lower_camel(field: str) -> str:
     )
 
 
+_FIELD_ARGS = ["include", "exclude", "update"]
+
+
+# TODO: remove this one when migrating to pydantic 2.0
+def safe_copy(model: BaseModel, **kwargs) -> BaseModel:
+    for k in _FIELD_ARGS:
+        for field in kwargs[k]:
+            if not hasattr(model, field):
+                msg = f"Unknown attribute {field} for {model.__class__}"
+                raise AttributeError(msg)
+
+    return model.copy(**kwargs)
+
+
 class BaseICIJModel(BaseModel):
     class Config:
         allow_mutation = False

--- a/neo4j-app/neo4j_app/run/run.py
+++ b/neo4j-app/neo4j_app/run/run.py
@@ -15,9 +15,7 @@ from neo4j_app.core.utils.logging import DATE_FMT, STREAM_HANDLER_FMT
 
 
 def debug_app():
-    config = AppConfig(
-        neo4j_project="Debug project",
-    )
+    config = AppConfig()
     app = create_app(config)
     return app
 
@@ -41,9 +39,7 @@ def _start_app(config_path: Optional[str] = None, force_migrations: bool = False
                 f, force_migrations=force_migrations
             )
     else:
-        config = AppConfig(
-            neo4j_project="test_project",
-        )
+        config = AppConfig()
     app = create_app(config)
     uvicorn_config = config.to_uvicorn()
     uvicorn.run(app, **uvicorn_config.dict())

--- a/neo4j-app/neo4j_app/run/run.py
+++ b/neo4j-app/neo4j_app/run/run.py
@@ -42,7 +42,7 @@ def _start_app(config_path: Optional[str] = None, force_migrations: bool = False
             )
     else:
         config = AppConfig(
-            neo4j_project="test-datashare-project",
+            neo4j_project="test_project",
         )
     app = create_app(config)
     uvicorn_config = config.to_uvicorn()

--- a/neo4j-app/neo4j_app/tests/app/test_admin.py
+++ b/neo4j-app/neo4j_app/tests/app/test_admin.py
@@ -13,7 +13,11 @@ from neo4j_app.core.objects import (
     NodeCSVs,
     RelationshipCSVs,
 )
-from neo4j_app.tests.conftest import TEST_INDEX, populate_es_with_doc_and_named_entities
+from neo4j_app.tests.conftest import (
+    TEST_INDEX,
+    TEST_PROJECT,
+    populate_es_with_doc_and_named_entities,
+)
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -30,7 +34,7 @@ async def test_post_named_entities_import_should_return_200(
     # Given
     test_client = test_client_module
     query = {"ids": {"values": ["doc-0"]}}
-    url = f"/admin/neo4j-csvs?database=neo4j&index={TEST_INDEX}"
+    url = f"/admin/neo4j-csvs?project={TEST_PROJECT}&index={TEST_INDEX}"
     payload = {"query": query}
 
     # When

--- a/neo4j-app/neo4j_app/tests/app/test_admin.py
+++ b/neo4j-app/neo4j_app/tests/app/test_admin.py
@@ -14,7 +14,6 @@ from neo4j_app.core.objects import (
     RelationshipCSVs,
 )
 from neo4j_app.tests.conftest import (
-    TEST_INDEX,
     TEST_PROJECT,
     populate_es_with_doc_and_named_entities,
 )
@@ -34,7 +33,7 @@ async def test_post_named_entities_import_should_return_200(
     # Given
     test_client = test_client_module
     query = {"ids": {"values": ["doc-0"]}}
-    url = f"/admin/neo4j-csvs?project={TEST_PROJECT}&index={TEST_INDEX}"
+    url = f"/admin/neo4j-csvs?project={TEST_PROJECT}"
     payload = {"query": query}
 
     # When

--- a/neo4j-app/neo4j_app/tests/app/test_documents.py
+++ b/neo4j-app/neo4j_app/tests/app/test_documents.py
@@ -7,7 +7,7 @@ from starlette.testclient import TestClient
 
 from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.core.objects import IncrementalImportResponse
-from neo4j_app.tests.conftest import TEST_INDEX, index_docs
+from neo4j_app.tests.conftest import TEST_INDEX, TEST_PROJECT, index_docs
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -49,7 +49,7 @@ def test_post_documents_import_should_return_200(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = f"/documents?database=neo4j&index={TEST_INDEX}"
+    url = f"/documents?project={TEST_PROJECT}&index={TEST_INDEX}"
     payload = {}
     if query is not None:
         payload["query"] = query

--- a/neo4j-app/neo4j_app/tests/app/test_documents.py
+++ b/neo4j-app/neo4j_app/tests/app/test_documents.py
@@ -7,13 +7,13 @@ from starlette.testclient import TestClient
 
 from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.core.objects import IncrementalImportResponse
-from neo4j_app.tests.conftest import TEST_INDEX, TEST_PROJECT, index_docs
+from neo4j_app.tests.conftest import TEST_PROJECT, index_docs
 
 
 @pytest_asyncio.fixture(scope="module")
 async def _populate_es(es_test_client_module: ESClient):
     es_client = es_test_client_module
-    index_name = TEST_INDEX
+    index_name = TEST_PROJECT
     n_docs = 10
     async for _ in index_docs(es_client, index_name=index_name, n=n_docs):
         pass
@@ -49,7 +49,7 @@ def test_post_documents_import_should_return_200(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = f"/documents?project={TEST_PROJECT}&index={TEST_INDEX}"
+    url = f"/documents?project={TEST_PROJECT}"
     payload = {}
     if query is not None:
         payload["query"] = query

--- a/neo4j-app/neo4j_app/tests/app/test_graphs.py
+++ b/neo4j-app/neo4j_app/tests/app/test_graphs.py
@@ -49,8 +49,8 @@ RETURN data;
                 },
                 query_filter="""MATCH (node)
 OPTIONAL MATCH (d)-[r]-(other)
-WHERE NOT any(l IN labels(node) WHERE l = 'Migration')
-    AND NOT any(l IN labels(other) WHERE l = 'Migration')
+WHERE NOT any(l IN labels(node) WHERE l = '_Migration')
+    AND NOT any(l IN labels(other) WHERE l = '_Migration')
 RETURN d, r, other
 """,
             ),
@@ -98,8 +98,8 @@ RETURN cypherStatements;
                 },
                 query_filter="""MATCH (node)
 OPTIONAL MATCH (d)-[r]-(other)
-WHERE NOT any(l IN labels(node) WHERE l = 'Migration')
-    AND NOT any(l IN labels(other) WHERE l = 'Migration')
+WHERE NOT any(l IN labels(node) WHERE l = '_Migration')
+    AND NOT any(l IN labels(other) WHERE l = '_Migration')
 RETURN d, r, other
 """,
             ),
@@ -138,7 +138,7 @@ async def test_post_graph_dump_should_return_200(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = "/graphs/dump?database=neo4j"
+    url = "/graphs/dump?project={TEST_PROJECT}"
     payload = {"query": query, "format": dump_format}
     exported_lines = ["exported\n", "lines"]
 
@@ -183,7 +183,7 @@ async def test_post_graph_dump_should_return_400_for_invalid_dump_format(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = "/graphs/dump?database=neo4j"
+    url = "/graphs/dump?project={TEST_PROJECT}"
     payload = {"query": None, "format": "idontexist"}
 
     # When/Then

--- a/neo4j-app/neo4j_app/tests/app/test_named_entities.py
+++ b/neo4j-app/neo4j_app/tests/app/test_named_entities.py
@@ -8,7 +8,6 @@ from starlette.testclient import TestClient
 from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.core.objects import IncrementalImportResponse
 from neo4j_app.tests.conftest import (
-    TEST_INDEX,
     TEST_PROJECT,
     populate_es_with_doc_and_named_entities,
 )
@@ -48,7 +47,7 @@ def test_post_named_entities_import_should_return_200(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = f"/named-entities?project={TEST_PROJECT}&index={TEST_INDEX}"
+    url = f"/named-entities?project={TEST_PROJECT}"
     payload = {}
     if query is not None:
         payload["query"] = query

--- a/neo4j-app/neo4j_app/tests/app/test_named_entities.py
+++ b/neo4j-app/neo4j_app/tests/app/test_named_entities.py
@@ -7,7 +7,11 @@ from starlette.testclient import TestClient
 
 from neo4j_app.core.elasticsearch import ESClient
 from neo4j_app.core.objects import IncrementalImportResponse
-from neo4j_app.tests.conftest import TEST_INDEX, populate_es_with_doc_and_named_entities
+from neo4j_app.tests.conftest import (
+    TEST_INDEX,
+    TEST_PROJECT,
+    populate_es_with_doc_and_named_entities,
+)
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -44,7 +48,7 @@ def test_post_named_entities_import_should_return_200(
     # pylint: disable=invalid-name,unused-argument
     # Given
     test_client = test_client_module
-    url = f"/named-entities?database=neo4j&index={TEST_INDEX}"
+    url = f"/named-entities?project={TEST_PROJECT}&index={TEST_INDEX}"
     payload = {}
     if query is not None:
         payload["query"] = query

--- a/neo4j-app/neo4j_app/tests/app/test_projects.py
+++ b/neo4j-app/neo4j_app/tests/app/test_projects.py
@@ -1,0 +1,36 @@
+import neo4j
+import pytest
+from starlette.testclient import TestClient
+
+from neo4j_app.core.neo4j import V_0_1_0
+from neo4j_app.core.neo4j.migrations.migrate import init_project
+
+_BASE_REGISTRY = [V_0_1_0]
+
+
+def test_project_init_should_return_201(test_client: TestClient):
+    # Given
+    project_name = "test-project"
+
+    # When
+    res = test_client.post(f"/projects/init?project={project_name}")
+
+    # Then
+    assert res.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_project_init_should_return_200(
+    test_client: TestClient, neo4j_test_driver: neo4j.AsyncDriver
+):
+    # Given
+    project_name = "test-project"
+    await init_project(
+        neo4j_test_driver, project_name, _BASE_REGISTRY, timeout_s=30, throttle_s=0.1
+    )
+
+    # When
+    res = test_client.post(f"/projects/init?project={project_name}")
+
+    # Then
+    assert res.status_code == 200

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -7,7 +7,6 @@ import random
 import traceback
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, Generator, Optional, Tuple, Union
-from unittest.mock import AsyncMock, MagicMock
 
 import neo4j
 import pytest

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -48,7 +48,6 @@ _INDEX_BODY = {
         }
     }
 }
-TEST_INDEX = "test-datashare-project"
 
 
 class MockedESClient(ESClientABC, metaclass=abc.ABCMeta):
@@ -108,7 +107,6 @@ def test_client_session(
     config = AppConfig(
         elasticsearch_address=f"http://127.0.0.1:{ELASTICSEARCH_TEST_PORT}",
         es_default_page_size=5,
-        neo4j_project="test-datashare-project",
         neo4j_app_host="127.0.0.1",
         neo4j_port=NEO4J_TEST_PORT,
         neo4j_user=NEO4J_TEST_USER,
@@ -181,7 +179,7 @@ def _make_test_client() -> ESClient:
 async def es_test_client_session() -> AsyncGenerator[ESClient, None]:
     es = _make_test_client()
     await es.indices.delete(index="_all")
-    await es.indices.create(index="test-datashare-project", body=_INDEX_BODY)
+    await es.indices.create(index=TEST_PROJECT, body=_INDEX_BODY)
     yield es
     await es.close()
 
@@ -190,7 +188,7 @@ async def es_test_client_session() -> AsyncGenerator[ESClient, None]:
 async def es_test_client_module() -> AsyncGenerator[ESClient, None]:
     es = _make_test_client()
     await es.indices.delete(index="_all")
-    await es.indices.create(index="test-datashare-project", body=_INDEX_BODY)
+    await es.indices.create(index=TEST_PROJECT, body=_INDEX_BODY)
     yield es
     await es.close()
 
@@ -199,7 +197,7 @@ async def es_test_client_module() -> AsyncGenerator[ESClient, None]:
 async def es_test_client() -> AsyncGenerator[ESClient, None]:
     es = _make_test_client()
     await es.indices.delete(index="_all")
-    await es.indices.create(index="test-datashare-project", body=_INDEX_BODY)
+    await es.indices.create(index=TEST_PROJECT, body=_INDEX_BODY)
     yield es
     await es.close()
 
@@ -339,7 +337,7 @@ def index_named_entities_ops(*, index_name: str, n: int) -> Generator[Dict, None
 
 
 async def index_docs(
-    client: ESClient, *, index_name: str, n: int
+    client: ESClient, *, n: int, index_name: str = TEST_PROJECT
 ) -> AsyncGenerator[Dict, None]:
     ops = index_docs_ops(index_name=index_name, n=n)
     # Let's wait to make this operation visible to the search
@@ -349,7 +347,10 @@ async def index_docs(
 
 
 async def index_noise(
-    client: ESClient, *, index_name: str, n: int
+    client: ESClient,
+    *,
+    n: int,
+    index_name: str = TEST_PROJECT,
 ) -> AsyncGenerator[Dict, None]:
     ops = index_noise_ops(index_name=index_name, n=n)
     # Let's wait to make this operation visible to the search
@@ -359,7 +360,7 @@ async def index_noise(
 
 
 async def index_named_entities(
-    client: ESClient, *, index_name: str, n: int
+    client: ESClient, *, n: int, index_name: str = TEST_PROJECT
 ) -> AsyncGenerator[Dict, None]:
     ops = index_named_entities_ops(index_name=index_name, n=n)
     # Let's wait to make this operation visible to the search
@@ -426,7 +427,7 @@ async def populate_es_with_doc_and_named_entities(
     es_test_client_module: ESClient, n: int
 ):
     es_client = es_test_client_module
-    index_name = TEST_INDEX
+    index_name = TEST_PROJECT
     # Index some Documents
     async for _ in index_docs(es_client, index_name=index_name, n=n):
         pass
@@ -492,7 +493,7 @@ async def _mocked_project_db_session(
 
 
 async def _mocked_project_registry_db(
-        neo4j_driver: neo4j.AsyncDriver # pylint: disable=unused-argument
+    neo4j_driver: neo4j.AsyncDriver,  # pylint: disable=unused-argument
 ) -> str:
     return NEO4J_COMMUNITY_DB
 

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -74,20 +74,6 @@ class MockedESClient(ESClientABC, metaclass=abc.ABCMeta):
         pass
 
 
-class AsyncContextManagerMock(AsyncMock):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        for key in ("aenter_return", "aexit_return"):
-            setattr(self, key, kwargs[key] if key in kwargs else MagicMock())
-
-    async def __aenter__(self):
-        return self.aenter_return
-
-    async def __aexit__(self, *args):
-        return self.aexit_return
-
-
 # Define a session level even_loop fixture to overcome limitation explained here:
 # https://github.com/tortoise/tortoise-orm/issues/638#issuecomment-830124562
 @pytest.fixture(scope="session")

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -491,7 +491,9 @@ async def _mocked_project_db_session(
         yield sess
 
 
-async def _mocked_project_registry_db(neo4j_driver: neo4j.AsyncDriver) -> str:
+async def _mocked_project_registry_db(
+        neo4j_driver: neo4j.AsyncDriver # pylint: disable=unused-argument
+) -> str:
     return NEO4J_COMMUNITY_DB
 
 

--- a/neo4j-app/neo4j_app/tests/core/elasticsearch/test_client.py
+++ b/neo4j-app/neo4j_app/tests/core/elasticsearch/test_client.py
@@ -16,7 +16,7 @@ from neo4j_app.core.elasticsearch.utils import HITS, SCROLL_ID_, SORT
 from neo4j_app.core.neo4j import get_neo4j_csv_writer
 from neo4j_app.tests.conftest import (
     MockedESClient,
-    TEST_INDEX,
+    TEST_PROJECT,
     fail_if_exception,
     index_noise,
 )
@@ -26,7 +26,7 @@ from neo4j_app.tests.conftest import (
 async def _index_noise(es_test_client_module: ESClient) -> ESClient:
     es_client = es_test_client_module
     n_noise = 22
-    async for _ in index_noise(es_client, index_name=TEST_INDEX, n=n_noise):
+    async for _ in index_noise(es_client, index_name=TEST_PROJECT, n=n_noise):
         pass
     yield es_client
 
@@ -123,9 +123,9 @@ async def test_write_concurrently_neo4j_csv(
     with (tmp_path / "import.csv").open("w") as f:
         writer = get_neo4j_csv_writer(f, header)
         writer.writeheader()
-        async with es_client.try_open_pit(index=TEST_INDEX, keep_alive="1m") as pit:
+        async with es_client.try_open_pit(index=TEST_PROJECT, keep_alive="1m") as pit:
             total_hits, _ = await es_client.write_concurrently_neo4j_csvs(
-                TEST_INDEX,
+                TEST_PROJECT,
                 query,
                 pit=pit,
                 nodes_f=f,

--- a/neo4j-app/neo4j_app/tests/core/elasticsearch/test_client.py
+++ b/neo4j-app/neo4j_app/tests/core/elasticsearch/test_client.py
@@ -48,15 +48,14 @@ async def test_es_client_should_search_with_pagination_size():
     # Given
     pagination = 666
     es_client = ESClient(pagination=pagination)
+    index = "test-datashare-project"
 
     # When
     with patch.object(AsyncElasticsearch, "search") as mocked_search:
         mocked_search.side_effect = _mocked_search
-        await es_client.search(body=None, index=TEST_INDEX)
+        await es_client.search(body=None, index=index)
         # Then
-        mocked_search.assert_called_once_with(
-            body=None, index=TEST_INDEX, size=pagination
-        )
+        mocked_search.assert_called_once_with(body=None, index=index, size=pagination)
 
 
 @pytest.mark.asyncio
@@ -64,15 +63,14 @@ async def test_os_client_should_search_with_pagination_size():
     # Given
     pagination = 666
     es_client = OSClient(pagination=pagination)
+    index = "test-datashare-project"
 
     # When
     with patch.object(AsyncOpenSearch, "search") as mocked_search:
         mocked_search.side_effect = _mocked_search
-        await es_client.search(body=None, index=TEST_INDEX)
+        await es_client.search(body=None, index=index)
         # Then
-        mocked_search.assert_called_once_with(
-            body=None, index=TEST_INDEX, size=pagination
-        )
+        mocked_search.assert_called_once_with(body=None, index=index, size=pagination)
 
 
 @pytest.mark.asyncio
@@ -82,11 +80,12 @@ async def test_es_client_should_raise_when_size_is_provided():
     es_client = ESClient(pagination=pagination)
     size = 100
     body = None
+    index = "test-datashare-project"
 
-    # When
-    expected_msg = "SClient run searches using the pagination_size"
+    # When/Then
+    expected_msg = "ESClient run searches using the pagination_size"
     with pytest.raises(ValueError, match=expected_msg):
-        await es_client.search(body=body, index=TEST_INDEX, size=size)
+        await es_client.search(body=body, index=index, size=size)
 
 
 @pytest.mark.asyncio

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from neo4j.exceptions import ClientError
 
 import neo4j_app
+from neo4j_app.constants import PROJECT_REGISTRY_DB
 from neo4j_app.core.neo4j import Migration, V_0_1_0, migrate_db_schemas
 from neo4j_app.core.neo4j.migrations import migrate
 from neo4j_app.core.neo4j.migrations.migrate import (
@@ -20,6 +21,7 @@ from neo4j_app.core.neo4j.migrations.migrate import (
 from neo4j_app.core.neo4j.projects import Project
 from neo4j_app.tests.conftest import (
     TEST_PROJECT,
+    fail_if_exception,
     mock_enterprise_,
     mocked_is_enterprise,
     wipe_db,
@@ -275,3 +277,92 @@ async def test_migrate_should_use_registry_db_when_with_enterprise_support(
     )
     with pytest.raises(ClientError, match=expected):
         await migrate_db_schemas(neo4j_driver, registry, timeout_s=10, throttle_s=0.1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_enterprise", [True, False])
+async def test_init_project(
+    neo4j_test_driver: neo4j.AsyncDriver, is_enterprise: bool, monkeypatch
+):
+    # Given
+    neo4j_driver = neo4j_test_driver
+    project_name = "test-project"
+    registry = [V_0_1_0]
+
+    if is_enterprise:
+        mock_enterprise_(monkeypatch)
+        with pytest.raises(ClientError) as ctx:
+            await init_project(
+                neo4j_driver, project_name, registry, timeout_s=1, throttle_s=1
+            )
+        expected_code = "Neo.ClientError.Statement.UnsupportedAdministrationCommand"
+        assert ctx.value.code == expected_code
+    else:
+        # When
+        existed = await init_project(
+            neo4j_driver, project_name, registry, timeout_s=1, throttle_s=1
+        )
+        assert not existed
+
+        # Then
+        projects = await retrieve_projects(neo4j_driver)
+        assert projects == [Project(name=project_name)]
+        db_migrations_recs, _, _ = await neo4j_driver.execute_query(
+            "MATCH (m:_Migration) RETURN m as migration"
+        )
+        db_migrations = [
+            Neo4jMigration.from_neo4j(rec, key="migration")
+            for rec in db_migrations_recs
+        ]
+        assert len(db_migrations) == 1
+        migration = db_migrations[0]
+        assert migration.version == V_0_1_0.version
+
+
+@pytest.mark.asyncio
+async def test_init_project_should_be_idempotent(neo4j_test_driver: neo4j.AsyncDriver):
+    # Given
+    neo4j_driver = neo4j_test_driver
+    project_name = "test-project"
+    registry = [V_0_1_0]
+    await init_project(neo4j_driver, project_name, registry, timeout_s=1, throttle_s=1)
+
+    # When
+    with fail_if_exception("init_project is not idempotent"):
+        existed = await init_project(
+            neo4j_driver, project_name, registry, timeout_s=1, throttle_s=1
+        )
+
+    # Then
+    assert existed
+
+    projects = await retrieve_projects(neo4j_driver)
+    assert projects == [Project(name=project_name)]
+    db_migrations_recs, _, _ = await neo4j_driver.execute_query(
+        "MATCH (m:_Migration) RETURN m as migration"
+    )
+    db_migrations = [
+        Neo4jMigration.from_neo4j(rec, key="migration") for rec in db_migrations_recs
+    ]
+    assert len(db_migrations) == 1
+    migration = db_migrations[0]
+    assert migration.version == V_0_1_0.version
+
+
+@pytest.mark.asyncio
+async def test_init_project_should_raise_for_reserved_name(
+    neo4j_test_driver_session: neo4j.AsyncDriver,
+):
+    # Given
+    neo4j_driver = neo4j_test_driver_session
+    project_name = PROJECT_REGISTRY_DB
+
+    # When/then
+    expected = (
+        'Bad luck, name "datashare-project-registry" is reserved for'
+        " internal use. Can't initialize project"
+    )
+    with pytest.raises(ValueError, match=expected):
+        await init_project(
+            neo4j_driver, project_name, registry=[], timeout_s=1, throttle_s=1
+        )

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -1,27 +1,43 @@
 import neo4j
 import pytest
 
-from neo4j_app.core.neo4j import create_document_and_ne_id_unique_constraint_tx
+from neo4j_app.core.neo4j.migrations.migrations import (
+    migration_v_0_1_0_tx,
+    migration_v_0_2_0_tx,
+)
 
 
 @pytest.mark.asyncio
-async def test_create_document_and_ne_id_unique_constraint_tx(
+async def test_migration_v_0_1_0_tx(
     neo4j_test_session: neo4j.AsyncSession,
 ):
-    # Given
+    # When
+    await neo4j_test_session.execute_write(migration_v_0_1_0_tx)
+
+    # Then
     constraints_res = await neo4j_test_session.run("SHOW CONSTRAINTS")
     existing_constraints = set()
     async for rec in constraints_res:
         existing_constraints.add(rec["name"])
+    assert "constraint_migration_unique_project_and_version" in existing_constraints
 
+
+@pytest.mark.asyncio
+async def test_migration_v_0_2_0_tx(
+    neo4j_test_session: neo4j.AsyncSession,
+):
     # When
-    await neo4j_test_session.execute_write(
-        create_document_and_ne_id_unique_constraint_tx
-    )
+    await neo4j_test_session.execute_write(migration_v_0_2_0_tx)
 
     # Then
+    indexes_res = await neo4j_test_session.run("SHOW INDEXES")
+    existing_indexes = set()
+    async for rec in indexes_res:
+        existing_indexes.add(rec["name"])
+    assert "index_ne_mention_norm" in existing_indexes
     constraints_res = await neo4j_test_session.run("SHOW CONSTRAINTS")
+    existing_constraints = set()
     async for rec in constraints_res:
         existing_constraints.add(rec["name"])
-    assert "constraint_document_unique_id" in existing_constraints
     assert "constraint_named_entity_unique_id" in existing_constraints
+    assert "constraint_document_unique_id" in existing_constraints

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_dumps.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_dumps.py
@@ -36,7 +36,7 @@ async def test_dump_full_graph_to_graphml(_populate_neo4j: neo4j.AsyncDriver):
     async for line in dump_graph(
         dump_format=dump_format,
         neo4j_driver=driver,
-        neo4j_db=neo4j.DEFAULT_DATABASE,
+        project=neo4j.DEFAULT_DATABASE,
         query=None,
     ):
         output.write(line)
@@ -86,7 +86,7 @@ RETURN person;
     async for line in dump_graph(
         dump_format=dump_format,
         neo4j_driver=driver,
-        neo4j_db=neo4j.DEFAULT_DATABASE,
+        project=neo4j.DEFAULT_DATABASE,
         query=query,
     ):
         output.write(line)
@@ -129,7 +129,7 @@ async def test_should_dump_full_graph_to_cypher(_populate_neo4j: neo4j.AsyncDriv
     # When
     output = StringIO()
     async for line in dump_graph(
-        dump_format=dump_format, neo4j_driver=driver, neo4j_db=neo4j.DEFAULT_DATABASE
+        dump_format=dump_format, neo4j_driver=driver, project=neo4j.DEFAULT_DATABASE
     ):
         output.write(line)
 
@@ -154,7 +154,7 @@ RETURN person;
     async for line in dump_graph(
         dump_format=dump_format,
         neo4j_driver=driver,
-        neo4j_db=neo4j.DEFAULT_DATABASE,
+        project=neo4j.DEFAULT_DATABASE,
         query=query,
     ):
         output.write(line)
@@ -180,6 +180,6 @@ async def test_should_raise_for_invalid_dump_format(
         async for _ in dump_graph(
             dump_format=dump_format,
             neo4j_driver=driver,
-            neo4j_db=neo4j.DEFAULT_DATABASE,
+            project=neo4j.DEFAULT_DATABASE,
         ):
             pass

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
@@ -18,6 +18,7 @@ from neo4j_app.tests.conftest import fail_if_exception, mock_enterprise_
 async def test_should_create_project_registry_db_with_enterprise_distribution(
     mock_enterprise,
 ):
+    # pylint: disable=unused-argument
     # Given
     mocked_driver = AsyncMock()
 

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from neo4j_app.core.neo4j.projects import create_project_registry_db
+from neo4j_app.run.run import debug_app
+
+
+@pytest.mark.asyncio
+async def test_should_create_project_registry_db_with_enterprise_distribution():
+    # Given
+    app = debug_app()
+    mocked_driver = AsyncMock()
+    with patch("neo4j_app.core.AppConfig.to_neo4j_driver") as mocked_get_driver:
+        # When
+        mocked_get_driver.return_value = mocked_driver
+        await create_project_registry_db(app)
+
+    # Then
+    mocked_driver.execute_query.assert_called_once_with(
+        "CREATE DATABASE $registry_db IF NOT EXISTS",
+        registry_db="datashare-project-registry",
+    )
+
+
+@pytest.mark.asyncio
+async def test_projects_tx():
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_init_project():
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_init_project_should_raise_for_reserved_name():
+    assert False
+
+
+@pytest.mark.asyncio
+async def test_init_project_should_be_idempotent():
+    assert False

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
@@ -1,17 +1,8 @@
 from unittest.mock import AsyncMock
 
-import neo4j
 import pytest
 
-from neo4j_app.constants import PROJECT_REGISTRY_DB
-from neo4j_app.core.neo4j import V_0_1_0
-from neo4j_app.core.neo4j.migrations.migrate import (
-    Neo4jMigration,
-    init_project,
-    retrieve_projects,
-)
-from neo4j_app.core.neo4j.projects import Project, create_project_registry_db
-from neo4j_app.tests.conftest import fail_if_exception, mock_enterprise_
+from neo4j_app.core.neo4j.projects import create_project_registry_db
 
 
 @pytest.mark.asyncio
@@ -30,80 +21,3 @@ async def test_should_create_project_registry_db_with_enterprise_distribution(
         "CREATE DATABASE $registry_db IF NOT EXISTS",
         registry_db="datashare-project-registry",
     )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("is_enterprise", [True, False])
-async def test_init_project(
-    neo4j_test_driver: neo4j.AsyncDriver, is_enterprise: bool, monkeypatch
-):
-    # Given
-    neo4j_driver = neo4j_test_driver
-    project_name = "test-project"
-    registry = [V_0_1_0]
-
-    if is_enterprise:
-        mock_enterprise_(monkeypatch)
-
-    # When
-    await init_project(neo4j_driver, project_name, registry, timeout_s=1, throttle_s=1)
-
-    # Then
-    projects = await retrieve_projects(neo4j_driver)
-    assert projects == [Project(name=project_name)]
-    db_migrations_recs, _, _ = await neo4j_driver.execute_query(
-        "MATCH (m:_Migration) RETURN m as migration"
-    )
-    db_migrations = [
-        Neo4jMigration.from_neo4j(rec, key="migration") for rec in db_migrations_recs
-    ]
-    assert len(db_migrations) == 1
-    migration = db_migrations[0]
-    assert migration.version == V_0_1_0.version
-
-
-@pytest.mark.asyncio
-async def test_init_project_should_be_idempotent(neo4j_test_driver: neo4j.AsyncDriver):
-    # Given
-    neo4j_driver = neo4j_test_driver
-    project_name = "test-project"
-    registry = [V_0_1_0]
-    await init_project(neo4j_driver, project_name, registry, timeout_s=1, throttle_s=1)
-
-    # When
-    with fail_if_exception("init_project is not idempotent"):
-        await init_project(
-            neo4j_driver, project_name, registry, timeout_s=1, throttle_s=1
-        )
-
-    # Then
-    projects = await retrieve_projects(neo4j_driver)
-    assert projects == [Project(name=project_name)]
-    db_migrations_recs, _, _ = await neo4j_driver.execute_query(
-        "MATCH (m:_Migration) RETURN m as migration"
-    )
-    db_migrations = [
-        Neo4jMigration.from_neo4j(rec, key="migration") for rec in db_migrations_recs
-    ]
-    assert len(db_migrations) == 1
-    migration = db_migrations[0]
-    assert migration.version == V_0_1_0.version
-
-
-@pytest.mark.asyncio
-async def test_init_project_should_raise_for_reserved_name(
-    neo4j_test_driver_session: neo4j.AsyncDriver,
-):
-    # Given
-    neo4j_driver = neo4j_test_driver_session
-    project_name = PROJECT_REGISTRY_DB
-
-    # When/then
-    expected = (
-        'Bad luck, name "datashare-project-registry" is reserved for'
-        " internal use. Can't initialize project"
-    )
-    with pytest.raises(ValueError, match=expected):
-        await init_project(
-            neo4j_driver, project_name, registry=[], timeout_s=1, throttle_s=1
-        )

--- a/neo4j-app/neo4j_app/tests/core/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/test_imports.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import itertools
 import json
 import os

--- a/src/main/java/org/icij/datashare/Neo4jClient.java
+++ b/src/main/java/org/icij/datashare/Neo4jClient.java
@@ -41,9 +41,9 @@ public class Neo4jClient {
     }
 
     public Objects.IncrementalImportResponse importDocuments(
-        String database, String index, Objects.IncrementalImportRequest body
+        String project, Objects.IncrementalImportRequest body
     ) {
-        String url = buildNeo4jUrl("/documents?database=" + database + "&index=" + index);
+        String url = buildNeo4jUrl("/documents?project=" + project);
         logger.debug("Importing documents to neo4j with request: {}",
             lazy(() -> MAPPER.writeValueAsString(body)));
         return doHttpRequest(
@@ -54,9 +54,9 @@ public class Neo4jClient {
     }
 
     public Objects.IncrementalImportResponse importNamedEntities(
-        String database, String index, Objects.IncrementalImportRequest body
+        String project, Objects.IncrementalImportRequest body
     ) {
-        String url = buildNeo4jUrl("/named-entities?database=" + database + "&index=" + index);
+        String url = buildNeo4jUrl("/named-entities?project=" + project);
         logger.debug("Importing named entities to neo4j with request: {}",
             lazy(() -> MAPPER.writeValueAsString(body)));
         return doHttpRequest(
@@ -66,7 +66,7 @@ public class Neo4jClient {
         );
     }
 
-    public InputStream dumpGraph(String database, Objects.Neo4jAppDumpRequest body)
+    public InputStream dumpGraph(String project, Objects.Neo4jAppDumpRequest body)
         throws URISyntaxException, IOException, InterruptedException {
         // Let's use the native HTTP client here as unirest doesn't offer an easy way to deal with
         // stream responses...
@@ -76,7 +76,7 @@ public class Neo4jClient {
         java.net.http.HttpRequest request =
             java.net.http.HttpRequest.newBuilder()
                 .version(HttpClient.Version.HTTP_1_1)
-                .uri(new URI(buildNeo4jUrl("/graphs/dump?database=" + database)))
+                .uri(new URI(buildNeo4jUrl("/graphs/dump?project=" + project)))
                 .POST(serializedBody)
                 .header("Content-Type", "application/json")
                 .build();
@@ -109,9 +109,9 @@ public class Neo4jClient {
 
     //CHECKSTYLE.OFF: AbbreviationAsWordInName
     public Objects.Neo4jCSVResponse exportNeo4jCSVs(
-        String database, String index, Objects.Neo4jAppNeo4jCSVRequest body
+        String projectId, Objects.Neo4jAppNeo4jCSVRequest body
     ) {
-        String url = buildNeo4jUrl("/admin/neo4j-csvs?database=" + database + "&index=" + index);
+        String url = buildNeo4jUrl("/admin/neo4j-csvs?project=" + projectId);
         logger.debug("Exporting data to neo4j csv with request: {}",
             lazy(() -> MAPPER.writeValueAsString(body)));
         return doHttpRequest(

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -434,8 +434,7 @@ public class Neo4jResource {
     ) {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
-        String db = neo4jProjectDatabase(projectId);
-        return client.importDocuments(db, projectId, request);
+        return client.importDocuments(projectId, request);
     }
 
     protected org.icij.datashare.Objects.IncrementalImportResponse importNamedEntities(
@@ -443,8 +442,7 @@ public class Neo4jResource {
     ) {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
-        String db = neo4jProjectDatabase(projectId);
-        return client.importNamedEntities(db, projectId, request);
+        return client.importNamedEntities(projectId, request);
     }
 
     //CHECKSTYLE.OFF: AbbreviationAsWordInName
@@ -455,12 +453,11 @@ public class Neo4jResource {
         //  the project
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
-        String database = neo4jProjectDatabase(projectId);
         // Define a temp dir
         Path exportDir = null;
         try {
             org.icij.datashare.Objects.Neo4jCSVResponse res =
-                client.exportNeo4jCSVs(database, projectId, request);
+                client.exportNeo4jCSVs(projectId, request);
             logger.info("Exported data from ES to neo4j, statistics: {}",
                 lazy(() -> MAPPER.writeValueAsString(res.metadata)));
             exportDir = Paths.get(res.path);
@@ -490,8 +487,7 @@ public class Neo4jResource {
             request);
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
-        String database = neo4jProjectDatabase(projectId);
-        return client.dumpGraph(database, neo4jAppRequest);
+        return client.dumpGraph(projectId, neo4jAppRequest);
     }
 
     protected InputStream sortedDumpGraph(
@@ -499,13 +495,12 @@ public class Neo4jResource {
     ) throws URISyntaxException, IOException, InterruptedException {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
-        String database = neo4jProjectDatabase(projectId);
         Statement statement = request.query.defaultQueryStatement(getDocumentNodesLimit());
         org.icij.datashare.Objects.Neo4jAppDumpRequest neo4jAppRequest =
             new org.icij.datashare.Objects.Neo4jAppDumpRequest(
                 request.format, statement.getCypher()
             );
-        return client.dumpGraph(database, neo4jAppRequest);
+        return client.dumpGraph(projectId, neo4jAppRequest);
     }
 
     private <T> Payload wrapNeo4jAppCall(Callable<T> responseProvider) {
@@ -548,15 +543,6 @@ public class Neo4jResource {
         if (!isLocal()) {
             throw new ForbiddenException();
         }
-    }
-
-    protected String neo4jProjectDatabase(String projectId) {
-        // For the neo4j community edition a single neo4j DB is available and its called neo4j,
-        // in this case the neo4jSingleProject is provided in the properties
-        if (this.neo4jSingleProjectId != null) {
-            return NEO4J_DEFAULT_DB;
-        }
-        return projectId;
     }
 
     protected void checkExtensionProject(String candidateProject) {

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -137,6 +137,8 @@ public class Neo4jResource {
         long elapsed = 0;
         while (elapsed < timeout) {
             if (isOpen(this.host, this.port) && pingSuccessful()) {
+                // TODO: in addition we should ping the Python service, ports might be open slightly
+                //  ahead of readiness
                 return;
             } else {
                 try {
@@ -147,8 +149,8 @@ public class Neo4jResource {
             }
             elapsed = System.currentTimeMillis() - start;
         }
-        long timeouts = timeout / 1000;
-        throw new RuntimeException("Couldn't start Python " + timeouts + "s after starting it !");
+        long timeoutS = timeout / 1000;
+        throw new RuntimeException("Couldn't start Python " + timeoutS + "s after starting it !");
     }
 
     protected boolean pingSuccessful() {

--- a/src/test/java/org/icij/datashare/Neo4jClientTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jClientTest.java
@@ -299,5 +299,37 @@ public class Neo4jClientTest {
                 () -> client.dumpGraph("unknown", body)
             ).getMessage()).isEqualTo("Bad Request\nDetail: Invalid project unknown");
         }
+
+        @Test
+        public void test_init_project() {
+            // Given
+            String newProject = "new-project";
+            neo4jApp.configure(routes -> routes.post("/projects/init", () -> new Payload(201)));
+            // When
+            boolean created = client.initProject(newProject);
+            // Then
+            assert created;
+        }
+
+        @Test
+        public void test_init_existing_project() {
+            // Given
+            String newProject = "existing-project";
+            neo4jApp.configure(routes -> routes.post("/projects/init", () -> new Payload(200)));
+            // When
+            boolean created = client.initProject(newProject);
+            // Then
+            assert !created;
+        }
+
+        @Test
+        public void test_config() {
+            // Given
+            neo4jApp.configure(routes -> routes.get("/config", (ctx) -> new HashMap<>()));
+            // When
+            HashMap<String, Object> res = client.config();
+            // Then
+            assertThat(res).isEqualTo(new HashMap<String, Object>());
+        }
     }
 }

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -420,10 +420,9 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_init_project_should_return_200() throws IOException, InterruptedException {
+        public void test_init_project_should_return_200() {
             // Given
             Neo4jResource.projects.clear();
-            neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
                 routes -> routes.post("/projects/init", context -> new Payload(200))
             );
@@ -438,10 +437,9 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_init_project_should_return_201() throws IOException, InterruptedException {
+        public void test_init_project_should_return_201() {
             // Given
             Neo4jResource.projects.clear();
-            neo4jAppResource.startServerProcess(false);
             neo4jApp.configure(
                 routes -> routes.post("/projects/init", context -> new Payload(201))
             );
@@ -456,10 +454,9 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_init_project_should_cache() throws IOException, InterruptedException {
+        public void test_init_project_should_cache() {
             // Given
             Neo4jResource.projects.add("foo-datashare");
-            neo4jAppResource.startServerProcess(false);
 
             neo4jApp.configure(
                 routes -> routes.post("/projects/init", context -> new Payload(418))
@@ -708,12 +705,10 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_check_extension_project_community()
-            throws IOException, InterruptedException {
+        public void test_check_extension_project_community() {
             // Given
             String project = "foo-datashare";
             assertThat(Neo4jResource.supportNeo4jEnterprise).isEqualTo(false);
-            neo4jAppResource.startServerProcess(false);
 
             // When
             try {
@@ -724,12 +719,10 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_check_extension_project_community_should_throw()
-            throws IOException, InterruptedException {
+        public void test_check_extension_project_community_should_throw() {
             // Given
             String project = "not-the-neo4j-project";
             assertThat(Neo4jResource.supportNeo4jEnterprise).isEqualTo(false);
-            neo4jAppResource.startServerProcess(false);
 
             // When
             String expected = "Invalid project\n"
@@ -754,8 +747,7 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_check_extension_project_enterprise()
-            throws IOException, InterruptedException {
+        public void test_check_extension_project_enterprise() {
             // Given
             String project = "some-project";
             assertThat(project).isNotEqualTo(SINGLE_PROJECT);


### PR DESCRIPTION
# PR description

This PR simplifies the extension deployment when the neo4j Enterprise distribution it also simplifies the Python extension API.

### Simplify app configuration

One key limitation of the neo4j community and enterprise disbtributions is that only one DB is allowed in the community version.
Since Datashare supports multiple projects, when using the community edition a project must be specified to the extension configuration. Only this project will be allowed to use neo4j related functionalities. This project can be specified through the `neo4jSingleProject` property. When running any project specific command with the community edition, the project name is matched against `neo4jSingleProject` and an exception is thrown in case of mistmatch.

The `neo4jSingleProject` was defaults to `local-datashare`. In the previous implementation, in order to deactivate the match of the project name the `neo4jSingleProject` property add to be set to `null` or to be emptied. This meant that by default the Enterprise distribution was not propertly supported and some configuration was needed.

This PR improves this behavior by deactivating the check when the enterprise support is detected on the Python app side.

The Python app now exposes its config and in particular reads the enterprise supports from the neo4j driver. This support is read by the Java extension and cached. Checks againts the `neo4jSingleProject` are only performed when in community edition.


### App deployment in enterprise mode

In the previous implementation, when using enterprise distribution, the app was expecting the neo4j project database to be pre existing in the neo4j instance.

This behavior requires a manual operation each time a new project is added to Datashare.

This PR creates a `/init?project=newProject` endpoint which sets up the neo4j environment for the `newProject`. In particular it will create a new neo4j DB for the project (for now with the `newProject` name).


### Simplify the Python app API

Previously an ES `index` and neo4j `database` were supplied to the Python API routes. The `index` parameter was always set to `projectId`. The `database` was deduced from the `neo4jSingleProject` property:
- when empty or null we assumed enterprise distribution and we set `database=projectId`
- when not null and not empty we assumed community distribution and set `database=neo4j` (which is the default DB name when in community edition)


In the PR we simplify the behavior be replacing the 2 `index` and `database` query parameters by a single `project` parameters. The Python app internally deduces the right ES index name and DB name from the project name and the driver enterprise support.


### Fix database migrations when in enterprise distribution

Prior to this PR, when using enterprise distribution, migration were applied to all databases found on the neo4j instance except the system one. The problem with this approach was that the neo4j instance might actually other DBs that Datashare's ones which would end up in one of the following sitution:
- the app would attempt to migrate a DB which shouldn't be accessed
- the neo4j user add no access to the DB and the migration would fail


This PR fixes that behavior by:
- creating a registry DB on the instance. This registry maps all project to the name of a database on the neo4j instance
- when running migrations at application startup, only DBs which are registered in the registry are migrated

Additionnally, when using enterprise distribution, I made the choice to move migration index located inside each project DB to the registry DB. This as the advantage not to mix the business data (documents, named entities) and the utility data (migrations) which makes cleaner dumps. As a consequence of this choice, this PR **is breaking any previous installations** (since there's none, it's considered acceptable) and the migration registry was reset and re-written from scratch.



# Changes

## `neo4j_app`

### Added
- Added the `/projects/init?project=<projectName>` API routes which through the underlying `core.neo4j.migrations.migrate.init_project` creates the project DB if not existing and migrate the project DB if necessary. When in community distribution, no DB is created (the default one is used)
- Register the `create_project_registry_db_`  `startup` event handler which creates the project registry DB if needed
- Added a `AppConfig.supports_neo4j_enterprise: Optional[bool] = None` attribute which is set when calling the `AppConfig.with_neo4j_support()`. When calling them method, the neo4j drivers call `CALL dbms.components()` and reads the enterprise support from it

### Changed
- Refactored migrations, in enterprise distribution migrations are now registered in a utility DB called `datashare-project-registry` which list projects, their DB name and migrations. Migrations are locked by project in this registry DB. In community edition everything happens in the default DB.
- Renamed `Migration` into `_Migration`. The `_NodeName` naming convention was chosen to distinguish between app data and utility data when in community distribution.
- Replaced the `index` and `database` parameters with the `project` one in all API routes
- Re-wrote the migration registry from scratch

## `src`
### Added 
- added the `POST /api/neo4j/init?project=<projectName>` API which initializes the given project and caches the project init
- updated `checkExtensionProject` to run when only neo4j community is supported. The supported is retrieved from the Python app config and cached
- added the `Neo4jClient.config()` to retrieve the Python app config and in particular the neo4j enterprise support
- added the `Neo4jClient.initProject(String project)` 
- updated the client reflect the python API changes


