### PR TITLE
chore: exit early when tasks no data to import

### DIFF
--- a/neo4j-app/neo4j_app/core/elasticsearch/client.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/client.py
@@ -282,6 +282,10 @@ class ESClientABC(metaclass=abc.ABCMeta):
         # return the result summaries
         for task in neo4j_tasks:
             task.cancel()
+        # If there's nothing to import workers are cancelled right await, no need to
+        # wait for tasks to end
+        if not n_imported:
+            return n_imported, []
         # Wait for all results to be there
         summaries = await asyncio.gather(*neo4j_tasks)
         summaries = sum(summaries, [])

--- a/neo4j-app/neo4j_app/tests/core/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/test_imports.py
@@ -75,6 +75,12 @@ async def _populate_es(
                 imported=20, nodes_created=20, relationships_created=19
             ),
         ),
+        # No query, let's check that only documents are inserted and not noise
+        (
+            {"ids": {"values": ["i-dont-exist"]}},
+            "type",
+            IncrementalImportResponse(),
+        ),
         # Match all query, let's check that only documents are inserted and not noise
         (
             {"match_all": {}},
@@ -188,6 +194,12 @@ async def test_import_documents_should_forward_db(
                 nodes_created=int(12 / 3 * 2),
                 relationships_created=int(12 / 3 * 2),
             ),
+        ),
+        # Match no ne
+        (
+            {"ids": {"values": ["i-dont-exist"]}},
+            "type",
+            IncrementalImportResponse(),
         ),
         # Match all query, let's check that only ents with doc are inserted
         (


### PR DESCRIPTION
# Changes
## `neo4j-app`
### Fixed
- Fixed potential `CancelledError` happening sometimes when there was no data to import, import workers were cancelled write away but still expected to complete their task