### PR TITLE
fix: wait for python app to respond to mark extension as ready

### DIFF
--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -125,8 +125,9 @@ public class Neo4jResource {
 
     protected void waitForServerToBeUp() {
         long start = System.currentTimeMillis();
-        long timeout = Long.parseLong(
-            this.propertiesProvider.get("neo4jAppStartTimeout").orElse("30"));
+        long timeout = 1000 * Long.parseLong(
+            this.propertiesProvider.get("neo4jAppStartTimeout").orElse("30")
+        );
         while (true) {
             if (isOpen(this.host, this.port) && pingSuccessful()) {
                 return;
@@ -137,7 +138,7 @@ public class Neo4jResource {
                     throw new RuntimeException("Thread killed while slipping", e);
                 }
             }
-            long elapsed = 1000 * (System.currentTimeMillis() - start);
+            long elapsed = System.currentTimeMillis() - start;
             if (elapsed > timeout) {
                 break;
             }

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -67,7 +67,7 @@ public class Neo4jResource {
     private static final HashMap<String, String> DEFAULT_NEO4J_PROPERTIES = new HashMap<>() {
         {
             put("neo4jAppPort", "8008");
-            put("neo4jAppStartTimeout", "30");
+            put("neo4jAppStartTimeoutS", "30");
             put("neo4jAppSyslogFacility", "LOCAL7");
             put("neo4jHost", "neo4j");
             put("neo4jPassword", "");
@@ -125,10 +125,11 @@ public class Neo4jResource {
 
     protected void waitForServerToBeUp() {
         long start = System.currentTimeMillis();
-        long timeout = 1000 * Long.parseLong(
-            this.propertiesProvider.get("neo4jAppStartTimeout").orElse("30")
-        );
-        while (true) {
+        long timeout = Long.parseLong(
+            this.propertiesProvider.get("neo4jAppStartTimeoutS").orElse("30")
+        ) * 1000;
+        long elapsed = 0;
+        while (elapsed < timeout) {
             if (isOpen(this.host, this.port) && pingSuccessful()) {
                 return;
             } else {
@@ -138,10 +139,7 @@ public class Neo4jResource {
                     throw new RuntimeException("Thread killed while slipping", e);
                 }
             }
-            long elapsed = System.currentTimeMillis() - start;
-            if (elapsed > timeout) {
-                break;
-            }
+            elapsed = System.currentTimeMillis() - start;
         }
         throw new RuntimeException("Couldn't start Python " + timeout + "s after starting it !");
     }

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -72,7 +72,7 @@ public class Neo4jResourceTest {
                     put("neo4jSingleProject", "foo-datashare");
                     // TODO: fix this path ?
                     put("neo4jStartServerCmd", "src/test/resources/shell_mock");
-                    put("neo4jAppStartTimeout", "2");
+                    put("neo4jAppStartTimeoutS", "2");
                 }
             });
         }


### PR DESCRIPTION
# Bug

Previously the Python app was marked as running as soon its port were open, in practice the app can take a little bit longer to respond

# Changes
## `src`
### Fixed
- `waitForServerToBeUp` now waits for the Python app to respond with a ping before marking the app as running
- fixed some flaky tests