### PR TITLE
quickfix: fix payload deserialization error

### DIFF
--- a/src/main/java/org/icij/datashare/HttpUtils.java
+++ b/src/main/java/org/icij/datashare/HttpUtils.java
@@ -1,12 +1,11 @@
 package org.icij.datashare;
 
-import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonIncludeProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -18,7 +17,7 @@ public class HttpUtils {
 
     static {
         EXT_MAPPER = new ObjectMapper().setTypeFactory(
-            MAPPER.getTypeFactory().withClassLoader(Neo4jResource.class.getClassLoader())
+            TypeFactory.defaultInstance().withClassLoader(Neo4jResource.class.getClassLoader())
         );
     }
 

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -519,8 +519,10 @@ public class Neo4jResource {
             return new Payload("application/problem+json", returned).withCode(500);
         } catch (ForbiddenException e) {
             return new Payload("application/problem+json", fromException(e)).withCode(403);
-        } catch (HttpUtils.BadRequest e) {
-            return new Payload("application/problem+json", fromException(e)).withCode(400);
+        } catch (HttpUtils.JacksonParseError e) {
+            HttpUtils.HttpError returned = fromException(e);
+            logger.error(returned.getMessageWithTrace());
+            return new Payload("application/problem+json", returned).withCode(400);
         } catch (Exception e) {
             HttpUtils.HttpError returned = fromException(e);
             logger.error("internal error on the java extension side {}",

--- a/src/main/java/org/icij/datashare/Objects.java
+++ b/src/main/java/org/icij/datashare/Objects.java
@@ -25,7 +25,7 @@ public class Objects {
 
         @JsonCreator
         DocumentSortItem(@JsonProperty("property") String property,
-                         @JsonProperty("query") SortDirection direction) {
+                         @JsonProperty("direction") SortDirection direction) {
             this.property = property;
             this.direction = direction;
         }


### PR DESCRIPTION
# PR description

This PR fixes in a quick and dirty manner a deserialization bug happening POSTing `DumpRequest` to the extension HTTP service.

The following payload is valid and correctly deserialized (if copy pasted in unit test)

```json
{
    "format": "cypher-shell",
    "query": {
        "where": {
            "startsWith": {
                "property": {
                    "variable": "doc",
                    "name": "id"
                },
                "value": {
                    "literal": "somePrefix"
                }
            }
        }
    }
}
```

however when sending the payload through HTTP to the `POST /api/neo4j/dump` route, it results in a:

```
Caused by: com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'org.icij.datashare.Neo4jUtils$VariableProperty' as a subtype of `org.icij.datashare.Neo4jUtils$VariableProperty`: Not a subtype
 at [Source: (String)"{
    "format": "cypher-shell",
    "query": {
        "where": {
            "startsWith": {
                "property": {
                    "variable": "doc",
                    "name": "id"
                },
                "value": {
                    "literal": "somePrefix"
                }
            }
        }
    }
}"; line: 7, column: 33] (through reference chain: org.icij.datashare.Objects$DumpRequest["query"]->org.icij.datashare.Objects$DumpQuery["where"]->org.icij.datashare.Neo4jUtils$StartsWith["property"])
```

The reason behind this is that when calling `parseContext`:
```java
protected static <T> T parseContext(Context context, Class<T> clazz) throws BadRequest {
    try {
        return context.extract(clazz);
    } catch (IOException | IllegalArgumentException e) {
        throw new BadRequest("Failed to parse request", e);
    }
}
```
fluent calls `CURRENT_OBJECT_MAPPER.convertValue(context.request.content(), TypeFactory.defaultInstance().constructType(type))` under the hood.

The above piece of code is roughly equivalent to 
```java
protected static <T> T parseContext(Context context, Class<T> clazz) throws BadRequest {
    try {
        return CURRENT_OBJECT_MAPPER.readValue(context.request().content(), clazz);
    } catch (IOException | IllegalArgumentException e) {
        throw new BadRequest("Failed to parse request", e);
    }
}
```

The problem is that the `ClassLoader` inside the `CURRENT_OBJECT_MAPPER._deserializationContext.getTypeFactory().findClass()` (called indisde `CURRENT_OBJECT_MAPPER._deserializationContext.resolveAndValidateSubType`) and the `clazz.classLoader` are not the same instance hence. 

IN `CURRENT_OBJECT_MAPPER._deserializationContext.getTypeFactory().findClass()` we have:

```java
ClassLoader loader = this.getClassLoader();
if (loader == null) {
    loader = Thread.currentThread().getContextClassLoader();
}
```

since the `TypeFactory` is not initialiaze with any loader the loader is set to `Thread.currentThread().getContextClassLoader()` which is the `org.icij.datashare.DynamicClassLoader`.


Hence when when calling:
```java
public final boolean isTypeOrSubTypeOf(Class<?> clz) {
        return this._class == clz || clz.isAssignableFrom(this._class);
}
```
`this._class == clz` is `false` as well as `clz.isAssignableFrom(this._class)` is `false` since both classes are not loaded from the same class loader.


### Quick fix

The was to define an extension object mapper and setting its class loader  to the extension class loader:
```java
static {
        EXT_MAPPER = new ObjectMapper().setTypeFactory(
            MAPPER.getTypeFactory().withClassLoader(Neo4jResource.class.getClassLoader())
        );
    }
```


### Proper fix

Potential solutions would probably involve:
- creating  utility methods in Datashare API `JsonObjectMapper`
- leveraging the `DeserializationContext` to temporarily set the `TypeFactory` (`withClassLoader`) of the `JsonObjectMapper.MAPPER`
- @bamthomas was also suggesting extending `JsonObjectMapper.MAPPER` with a new module at the extension initialization


# Changes

## `src`
### Fixed
- Defined a `HttpUtils.EXT_MAPPER` to deserialize payloads and used it in `HttpUtils.parseContext`
### Changed
- Renamed `HttpUtils.BadRequest` into `JacksonParseError` which now inherits from `RuntimeError`