### PR TITLE
fix: remove `size` from `_poll_scroll_search_pages`

### DIFF
--- a/neo4j-app/neo4j_app/core/elasticsearch/client.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/client.py
@@ -170,7 +170,6 @@ class ESClientABC(metaclass=abc.ABCMeta):
         query: Dict,
         scroll: str,
         sort: Optional[List[Dict]] = None,
-        size: Optional[int] = None,
         **kwargs,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         retrying = self._async_retrying()
@@ -181,7 +180,6 @@ class ESClientABC(metaclass=abc.ABCMeta):
             index=index,
             body=query,
             scroll=scroll,
-            size=size,
             sort=sort,
             **kwargs,
         )


### PR DESCRIPTION
# PR description

Following #91 it appeared that `_poll_scroll_search_pages` was still trying to use another `size` than the es default one. It didn't popped up in the test since most test run using a recent version of ES which polls using a PIT search rather than  a scrolled search.

# Changes
## Fixed
- Remove `size` paramter from `_poll_scroll_search_pages`
