### PR TITLE
feature: email directed relationships

### DIFF
--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -30,6 +30,16 @@ PROJECT_RUNS_MIGRATION = "_RUNS"
 PROJECT_NAME = "name"
 PROJECT_NODE = "_Project"
 
+# TODO: check that it the name retained in https://github.com/ICIJ/datashare/pull/1180
+EMAIL_HEADER = "emailHeader"
+EMAIL_RECEIVED_REL_LABEL = "RECEIVED"
+EMAIL_SENT_REL_LABEL = "SENT"
+# TODO: check the naming here, we use "fields" here since the RFC specification
+#  https://www.rfc-editor.org/rfc/rfc2822 refers to this kind of header as fields, this
+#  is not very ubiquitous nor end user friendly. FTM and other knowledge base don't
+#  seem to propose a naming for these fields. "role" might be friendly
+EMAIL_REL_HEADER_FIELDS = "fields"
+
 MIGRATION_COMPLETED = "completed"
 MIGRATION_LABEL = "label"
 MIGRATION_NODE = "_Migration"
@@ -51,6 +61,8 @@ NE_EXTRACTOR_LANG = "extractorLanguage"
 NE_MENTION = "mention"
 NE_MENTION_NORM = "mentionNorm"
 NE_MENTION_NORM_TEXT_LENGTH = "mentionNormTextLength"
+NE_METADATA = "metadata"
+
 NE_NODE = "NamedEntity"
 NE_OFFSETS = "offsets"
 NE_COLUMNS = {
@@ -62,6 +74,8 @@ NE_COLUMNS = {
     NE_MENTION: {},
     NE_MENTION_NORM: {},
     NE_MENTION_NORM_TEXT_LENGTH: {NEO4J_CSV_COL: "INT"},
+    # TODO: this shouldn't be imported in admin imports...
+    NE_METADATA: {},
     NE_OFFSETS: {NEO4J_CSV_COL: "LONG[]"},
 }
 NE_ES_SOURCES = list(NE_COLUMNS) + [JOIN, NE_DOC_ID]

--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -14,7 +14,7 @@ DOC_ID_CSV = f"ID({DOC_NODE})"
 DOC_EXTRACTION_DATE = "extractionDate"
 DOC_PATH = "path"
 DOC_ROOT_ID = "rootDocument"
-DOC_ROOT_REL_LABEL = "HAS_PARENT"
+DOC_ROOT_TYPE = "HAS_PARENT"
 DOC_COLUMNS = {
     DOC_ID: {NEO4J_CSV_COL: DOC_ID_CSV},
     DOC_DIRNAME: {},
@@ -31,14 +31,29 @@ PROJECT_NAME = "name"
 PROJECT_NODE = "_Project"
 
 # TODO: check that it the name retained in https://github.com/ICIJ/datashare/pull/1180
+EMAIL_CATEGORY = "EMAIL"
 EMAIL_HEADER = "emailHeader"
-EMAIL_RECEIVED_REL_LABEL = "RECEIVED"
-EMAIL_SENT_REL_LABEL = "SENT"
+EMAIL_RECEIVED_TYPE = "RECEIVED"
+EMAIL_SENT_TYPE = "SENT"
 # TODO: check the naming here, we use "fields" here since the RFC specification
 #  https://www.rfc-editor.org/rfc/rfc2822 refers to this kind of header as fields, this
 #  is not very ubiquitous nor end user friendly. FTM and other knowledge base don't
 #  seem to propose a naming for these fields. "role" might be friendly
 EMAIL_REL_HEADER_FIELDS = "fields"
+
+EMAIL_REL_COLS = {
+    EMAIL_REL_HEADER_FIELDS: {NEO4J_CSV_COL: "STRING[]"},
+}
+
+# TODO: check that this list is exhaustive, we know it isn't !!!
+SENT_EMAIL_HEADERS = {"tika_metadata_message_from"}
+# TODO: check that this list is exhaustive, we know it isn't !!!
+RECEIVED_EMAIL_HEADERS = {
+    "tika_metadata_message_bcc",
+    "tika_metadata_message_cc",
+    "tika_metadata_message_to",
+}
+
 
 MIGRATION_COMPLETED = "completed"
 MIGRATION_LABEL = "label"

--- a/neo4j-app/neo4j_app/core/neo4j/documents.py
+++ b/neo4j-app/neo4j_app/core/neo4j/documents.py
@@ -11,7 +11,7 @@ from neo4j_app.constants import (
     DOC_NODE,
     DOC_PATH,
     DOC_ROOT_ID,
-    DOC_ROOT_REL_LABEL,
+    DOC_ROOT_TYPE,
 )
 
 
@@ -35,7 +35,7 @@ CALL {{
     WITH doc, row
     WHERE doc.{DOC_ID} = row.{DOC_ID} and row.{DOC_ROOT_ID} IS NOT NULL
     MERGE (root:{DOC_NODE} {{{DOC_ID}: row.{DOC_ROOT_ID}}})
-    MERGE (doc)-[:{DOC_ROOT_REL_LABEL}]->(root)
+    MERGE (doc)-[:{DOC_ROOT_TYPE}]->(root)
 }} IN TRANSACTIONS OF $batchSize ROWS
 """
     res = await neo4j_session.run(query, rows=records, batchSize=transaction_batch_size)

--- a/neo4j-app/neo4j_app/core/neo4j/named_entities.py
+++ b/neo4j-app/neo4j_app/core/neo4j/named_entities.py
@@ -5,6 +5,10 @@ import neo4j
 from neo4j_app.constants import (
     DOC_ID,
     DOC_NODE,
+    EMAIL_HEADER,
+    EMAIL_RECEIVED_REL_LABEL,
+    EMAIL_REL_HEADER_FIELDS,
+    EMAIL_SENT_REL_LABEL,
     NE_APPEARS_IN_DOC,
     NE_CATEGORY,
     NE_DOC_ID,
@@ -14,9 +18,33 @@ from neo4j_app.constants import (
     NE_ID,
     NE_IDS,
     NE_MENTION_NORM,
+    NE_METADATA,
     NE_NODE,
     NE_OFFSETS,
 )
+
+# TODO: check that this list is exhaustive, we know it isn't !!!
+_SENT_EMAIL_HEADERS = ["tika_metadata_message_from"]
+# TODO: check that this list is exhaustive, we know it isn't !!!
+_RECEIVED_EMAIL_HEADERS = [
+    "tika_metadata_message_bcc",
+    "tika_metadata_message_cc",
+    "tika_metadata_message_to",
+]
+
+_MERGE_SENT_EMAIL = f"""MERGE (mention)-[emailRel:{EMAIL_SENT_REL_LABEL}]->(doc)
+ON CREATE
+    SET emailRel.{EMAIL_REL_HEADER_FIELDS} = [row.{NE_METADATA}.{EMAIL_HEADER}]
+ON MATCH
+    SET emailRel.{EMAIL_REL_HEADER_FIELDS} =  apoc.coll.toSet(emailRel.{EMAIL_REL_HEADER_FIELDS} + row.{NE_METADATA}.{EMAIL_HEADER})
+RETURN emailRel"""
+
+_MERGE_RECEIVED_EMAIL = f"""MERGE (mention)-[emailRel:{EMAIL_RECEIVED_REL_LABEL}]->(doc)
+ON CREATE
+    SET emailRel.{EMAIL_REL_HEADER_FIELDS} = [row.{NE_METADATA}.{EMAIL_HEADER}]
+ON MATCH
+    SET emailRel.{EMAIL_REL_HEADER_FIELDS} =  apoc.coll.toSet(emailRel.{EMAIL_REL_HEADER_FIELDS} + row.{NE_METADATA}.{EMAIL_HEADER})
+RETURN emailRel"""
 
 
 async def import_named_entity_rows(
@@ -44,9 +72,31 @@ CALL {{
             rel.{NE_IDS} = apoc.coll.toSet(rel.{NE_IDS} + row.{NE_ID}),
             rel.{NE_EXTRACTORS} = apoc.coll.toSet(rel.{NE_EXTRACTORS} + row.{NE_EXTRACTOR}),
             rel.{NE_OFFSETS} = apoc.coll.toSet(rel.{NE_OFFSETS} + row.{NE_OFFSETS})
+    WITH mention, doc, row
+    CALL apoc.do.case(
+        [
+            row.{NE_METADATA} IS NOT NULL AND row.{NE_METADATA}.{EMAIL_HEADER} IN $sentHeaders, '{_MERGE_SENT_EMAIL}',
+            row.{NE_METADATA} IS NOT NULL AND row.{NE_METADATA}.{EMAIL_HEADER} IN $receivedHeaders, '{_MERGE_RECEIVED_EMAIL}'
+        ],
+        'RETURN NULL as emailRel',
+      {{
+        mention: mention,
+        doc: doc,
+        row: row
+      }}
+    ) YIELD value
+    WITH value AS ignored, mention
+    RETURN mention
 }} IN TRANSACTIONS OF $batchSize ROWS
+RETURN mention 
 """
-    res = await neo4j_session.run(query, rows=records, batchSize=transaction_batch_size)
+    res = await neo4j_session.run(
+        query,
+        rows=records,
+        batchSize=transaction_batch_size,
+        sentHeaders=_SENT_EMAIL_HEADERS,
+        receivedHeaders=_RECEIVED_EMAIL_HEADERS,
+    )
     summary = await res.consume()
     return summary
 

--- a/neo4j-app/neo4j_app/core/neo4j/named_entities.py
+++ b/neo4j-app/neo4j_app/core/neo4j/named_entities.py
@@ -6,9 +6,9 @@ from neo4j_app.constants import (
     DOC_ID,
     DOC_NODE,
     EMAIL_HEADER,
-    EMAIL_RECEIVED_REL_LABEL,
+    EMAIL_RECEIVED_TYPE,
     EMAIL_REL_HEADER_FIELDS,
-    EMAIL_SENT_REL_LABEL,
+    EMAIL_SENT_TYPE,
     NE_APPEARS_IN_DOC,
     NE_CATEGORY,
     NE_DOC_ID,
@@ -21,25 +21,19 @@ from neo4j_app.constants import (
     NE_METADATA,
     NE_NODE,
     NE_OFFSETS,
+    RECEIVED_EMAIL_HEADERS,
+    SENT_EMAIL_HEADERS,
 )
 
-# TODO: check that this list is exhaustive, we know it isn't !!!
-_SENT_EMAIL_HEADERS = ["tika_metadata_message_from"]
-# TODO: check that this list is exhaustive, we know it isn't !!!
-_RECEIVED_EMAIL_HEADERS = [
-    "tika_metadata_message_bcc",
-    "tika_metadata_message_cc",
-    "tika_metadata_message_to",
-]
 
-_MERGE_SENT_EMAIL = f"""MERGE (mention)-[emailRel:{EMAIL_SENT_REL_LABEL}]->(doc)
+_MERGE_SENT_EMAIL = f"""MERGE (mention)-[emailRel:{EMAIL_SENT_TYPE}]->(doc)
 ON CREATE
     SET emailRel.{EMAIL_REL_HEADER_FIELDS} = [row.{NE_METADATA}.{EMAIL_HEADER}]
 ON MATCH
     SET emailRel.{EMAIL_REL_HEADER_FIELDS} =  apoc.coll.toSet(emailRel.{EMAIL_REL_HEADER_FIELDS} + row.{NE_METADATA}.{EMAIL_HEADER})
 RETURN emailRel"""
 
-_MERGE_RECEIVED_EMAIL = f"""MERGE (mention)-[emailRel:{EMAIL_RECEIVED_REL_LABEL}]->(doc)
+_MERGE_RECEIVED_EMAIL = f"""MERGE (mention)-[emailRel:{EMAIL_RECEIVED_TYPE}]->(doc)
 ON CREATE
     SET emailRel.{EMAIL_REL_HEADER_FIELDS} = [row.{NE_METADATA}.{EMAIL_HEADER}]
 ON MATCH
@@ -94,8 +88,8 @@ RETURN mention
         query,
         rows=records,
         batchSize=transaction_batch_size,
-        sentHeaders=_SENT_EMAIL_HEADERS,
-        receivedHeaders=_RECEIVED_EMAIL_HEADERS,
+        sentHeaders=list(SENT_EMAIL_HEADERS),
+        receivedHeaders=list(RECEIVED_EMAIL_HEADERS),
     )
     summary = await res.consume()
     return summary

--- a/neo4j-app/neo4j_app/tests/app/test_admin.py
+++ b/neo4j-app/neo4j_app/tests/app/test_admin.py
@@ -74,6 +74,12 @@ async def test_post_named_entities_import_should_return_200(
                 relationship_paths=["entity-docs.csv"],
                 n_relationships=2,
             ),
+            RelationshipCSVs(
+                types=[],
+                header_path="email-docs-header.csv",
+                relationship_paths=["email-docs.csv"],
+                n_relationships=0,
+            ),
         ],
     )
     assert res.metadata == expected_metadata

--- a/neo4j-app/neo4j_app/tests/core/elasticsearch/test_to_neo4j.py
+++ b/neo4j-app/neo4j_app/tests/core/elasticsearch/test_to_neo4j.py
@@ -1,0 +1,17 @@
+from neo4j_app.core.elasticsearch.to_neo4j import es_to_neo4j_named_entity_row
+
+
+def test_es_to_neo4j_named_entity_row_should_contain_metadata():
+    # Given
+    es_document = {
+        "_id": "someId",
+        "_source": {
+            "mentionNorm": "dev@icij.org",
+            "metadata": {"emailHeader": "someHeader"},
+            "join": {"parent": "docId"},
+        },
+    }
+    # When
+    neo4j_row = es_to_neo4j_named_entity_row(es_document)[0]
+    # Then
+    assert "metadata" in neo4j_row


### PR DESCRIPTION
# TODO
- [x] update the named according to https://github.com/ICIJ/datashare/pull/1180
- [x] update the naming in this PR according to the chosen naming...


# PR description

This PR makes the most of work done in https://github.com/ICIJ/datashare/pull/1180 to import directed relationships for `:NamedEntity:EMAIL` when they are available.

## Choices
### Incremental imports
Rather than implementing a new pipeline for email relationships, they are imported while importing `NamedEntity` inside the graph.
Modifying incremental imports was as simple as updating `core.neo4j.import_named_entity_rows` to create `:SENT`:`:RECEIVED` relationships based on `NamedEntity.metadata.emailHeader`

### Admin imports
Updating admin import required a bit more work and updates inside the `core.import` module.

## Data model

Two types of relationships were created

### `:SENT`

When the `NamedEntity.metadata.emailHeader` contains one of the following values:
- TODO

The following relationship is created:
```
(ne:NamedEntity:EMAIL { mentionNorm: "dev@icij.org" })-[:SENT { fields: ["tikka_metadata_message_from"] }]->(doc:Document)
```

when several sending headers are found for the same address they are aggregated inside the `fields` property.


### `:RECEIVED`

When the `NamedEntity.metadata.emailHeader` contains one of the following values:
- TODO

The following relationship is created:
```
(ne:NamedEntity:EMAIL { mentionNorm: "dev@icij.org" })-[:SENT { fields: ["tikka_metadata_message_from"] }]->(doc:Document)
```
when several received headers are found for the same address they are aggregated inside the `fields` property.

## What about when we have no metadata ?
 
`NamedEntity:EMAIL` are still linked to their document through the regular `(ne:NamedEntity:EMAIL)-[:APPEARS_IN]->(doc:Document)`


# Changes
## `neo4j-app`
### Changed
- updated `core.neo4j.import_named_entity_rows` to create `:SENT`:`:RECEIVED` relationships based on `NamedEntity.metadata.emailHeader`
- updated `core.import` to dump email relationships CSVs in admin imports