### PR TITLE
fix: `Neo4jResource` dependency injection

### DIFF
--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -11,6 +11,8 @@ import static org.icij.datashare.text.Project.isAllowed;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -37,7 +39,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.inject.Inject;
 import kong.unirest.Unirest;
 import kong.unirest.apache.ApacheClient;
 import net.codestory.http.Context;
@@ -52,6 +53,7 @@ import org.neo4j.cypherdsl.core.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@Singleton
 @Prefix("/api/neo4j")
 public class Neo4jResource {
     private final Repository repository;


### PR DESCRIPTION
# Bug description

I was importing the  `Inject` annotation and also forgot to mark it as Singleton` which resulted in my `Neo4jResource` being recreated many times. I was seing it in the log but couldn't find the source of the bug...

# Changes
## `src`
### Fixed
- made `Neo4jResource` a guice singleton
- fixed the `Inject` annotation for `Neo4jResource`