### PR TITLE
feature: async tasks creation in java

### DIFF
--- a/neo4j-app/neo4j_app/core/utils/pydantic.py
+++ b/neo4j-app/neo4j_app/core/utils/pydantic.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import cached_property
 from typing import cast
 
@@ -55,3 +56,8 @@ class IgnoreExtraModel(BaseICIJModel):
 class NoEnumModel(BaseICIJModel):
     class Config:
         use_enum_values = False
+
+
+class ISODatetime(BaseICIJModel):
+    class Config:
+        json_encoders = {datetime: lambda x: x.isoformat()}

--- a/neo4j-app/neo4j_app/icij_worker/task.py
+++ b/neo4j-app/neo4j_app/icij_worker/task.py
@@ -12,7 +12,8 @@ from pydantic import Field, validator
 
 from neo4j_app.constants import TASK_NODE
 from neo4j_app.core.utils.pydantic import (
-    ISODatetime, LowerCamelCaseModel,
+    ISODatetime,
+    LowerCamelCaseModel,
     NoEnumModel,
     safe_copy,
 )

--- a/neo4j-app/neo4j_app/icij_worker/task.py
+++ b/neo4j-app/neo4j_app/icij_worker/task.py
@@ -12,7 +12,7 @@ from pydantic import Field, validator
 
 from neo4j_app.constants import TASK_NODE
 from neo4j_app.core.utils.pydantic import (
-    LowerCamelCaseModel,
+    ISODatetime, LowerCamelCaseModel,
     NoEnumModel,
     safe_copy,
 )
@@ -79,7 +79,7 @@ def status_precedence(state: TaskStatus) -> int:
     return PRECEDENCE_LOOKUP[state]
 
 
-class Task(NoEnumModel, LowerCamelCaseModel):
+class Task(NoEnumModel, LowerCamelCaseModel, ISODatetime):
     id: str
     type: str
     inputs: Dict[str, Any] = Field(default_factory=dict)

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.konghq</groupId>
             <artifactId>unirest-java</artifactId>
-            <version>3.11.09</version>
+            <version>3.14.5</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/icij/datashare/Neo4jClient.java
+++ b/src/main/java/org/icij/datashare/Neo4jClient.java
@@ -52,6 +52,7 @@ public class Neo4jClient {
     public Neo4jClient(int port) {
         this.port = port;
         this.httpClient = java.net.http.HttpClient.newHttpClient();
+        Unirest.config().reset();
         Unirest.config()
             .setObjectMapper(makeObjectMapper())
             .socketTimeout(HTTP_TIMEOUT)

--- a/src/main/java/org/icij/datashare/Neo4jClient.java
+++ b/src/main/java/org/icij/datashare/Neo4jClient.java
@@ -8,16 +8,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JavaType;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
-import java.lang.reflect.Type;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.util.HashMap;
-import java.util.List;
 import kong.unirest.Config;
 import kong.unirest.GenericType;
 import kong.unirest.HttpRequestSummary;
@@ -191,8 +187,8 @@ public class Neo4jClient {
             .getBody();
     }
 
-    // Generics don't play well Unirest, returning Objects.TaskError[] instead of List<TaskError>
-    // helps
+    // TODO: generics don't play well Unirest, returning Objects.TaskError[] instead of
+    //  List<TaskError> helps
     protected Objects.TaskError[] taskErrors(String taskId, String project) {
         String url = buildNeo4jUrl("/tasks/" + taskId + "/errors?project=" + project);
         logger.debug("Getting task {} errors", taskId);
@@ -278,7 +274,8 @@ public class Neo4jClient {
                 try {
                     // TODO: this doesn't work properly and returns List<HashMap> instead of
                     //  List<G>... When T =  List<G>
-                    TypeReference<T> typeRef = new TypeReference<>() {};
+                    TypeReference<T> typeRef = new TypeReference<>() {
+                    };
                     return MAPPER.readValue(value, typeRef);
                 } catch (JsonProcessingException e) {
                     throw new RuntimeException(e);

--- a/src/main/java/org/icij/datashare/Neo4jClient.java
+++ b/src/main/java/org/icij/datashare/Neo4jClient.java
@@ -2,7 +2,6 @@ package org.icij.datashare;
 
 import static org.icij.datashare.HttpUtils.fromException;
 import static org.icij.datashare.LoggingUtils.lazy;
-import static org.icij.datashare.Objects.GraphNodesCount;
 import static org.icij.datashare.Objects.IncrementalImportRequest;
 import static org.icij.datashare.Objects.IncrementalImportResponse;
 import static org.icij.datashare.Objects.Neo4jAppDumpRequest;
@@ -85,12 +84,6 @@ public class Neo4jClient {
         logger.debug("Fetching Python app config");
         return Unirest.get(url).asObject(new GenericType<HashMap<String, Object>>() {
         }).getBody();
-    }
-
-    protected GraphNodesCount graphNodesCount(String project) {
-        String url = buildNeo4jUrl("/graphs/nodes/count?project=" + project);
-        logger.debug("Counting graph nodes");
-        return Unirest.get(url).asObject(GraphNodesCount.class).getBody();
     }
 
     protected String fullImport(String project) {

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -264,15 +264,6 @@ public class Neo4jResource {
         });
     }
 
-    @Get("/tasks/:taskId?project=:project")
-    public Payload getTask(String taskId, String project, Context context) {
-        return wrapNeo4jAppCall(() -> {
-            checkProjectAccess(project, context);
-            checkTaskAccess(taskId, project, context);
-            return task(taskId, project);
-        });
-    }
-
     protected void checkNeo4jAppStarted() {
         if (neo4jAppPid() == null) {
             throw new Neo4jNotRunningError();

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -264,6 +264,15 @@ public class Neo4jResource {
         });
     }
 
+    @Get("/tasks/:taskId?project=:project")
+    public Payload getTask(String taskId, String project, Context context) {
+        return wrapNeo4jAppCall(() -> {
+            checkProjectAccess(project, context);
+            checkTaskAccess(taskId, project, context);
+            return task(taskId, project);
+        });
+    }
+
     protected void checkNeo4jAppStarted() {
         if (neo4jAppPid() == null) {
             throw new Neo4jNotRunningError();

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -260,15 +260,6 @@ public class Neo4jResource {
         });
     }
 
-    @Get("/graphs/nodes/count?project=:project")
-    public Payload getGraphNodesCount(String project, Context context) {
-        return wrapNeo4jAppCall(() -> {
-            checkProjectAccess(project, context);
-            return this.client.graphNodesCount(project);
-        });
-    }
-
-
     protected void checkNeo4jAppStarted() {
         if (neo4jAppPid() == null) {
             throw new Neo4jNotRunningError();

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -6,6 +6,15 @@ import static org.icij.datashare.HttpUtils.fromException;
 import static org.icij.datashare.HttpUtils.parseContext;
 import static org.icij.datashare.LoggingUtils.lazy;
 import static org.icij.datashare.Neo4jAppLoader.getExtensionVersion;
+import static org.icij.datashare.Objects.DumpQuery;
+import static org.icij.datashare.Objects.DumpRequest;
+import static org.icij.datashare.Objects.IncrementalImportRequest;
+import static org.icij.datashare.Objects.IncrementalImportResponse;
+import static org.icij.datashare.Objects.Neo4jAppDumpRequest;
+import static org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest;
+import static org.icij.datashare.Objects.Neo4jCSVResponse;
+import static org.icij.datashare.Objects.SortedDumpRequest;
+import static org.icij.datashare.Objects.StartNeo4jAppRequest;
 import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
 import static org.icij.datashare.text.Project.isAllowed;
 
@@ -162,9 +171,8 @@ public class Neo4jResource {
         return wrapNeo4jAppCall(() -> {
                 boolean forceMigrations = false;
                 if (!context.request().content().isBlank()) {
-                    forceMigrations = parseContext(context,
-                        org.icij.datashare.Objects.StartNeo4jAppRequest.class
-                    ).forceMigration;
+                    forceMigrations = parseContext(
+                        context, StartNeo4jAppRequest.class).forceMigration;
                 }
                 boolean alreadyRunning = this.startNeo4jApp(forceMigrations);
                 return new Payload(new ServerStartResponse(alreadyRunning));
@@ -205,8 +213,8 @@ public class Neo4jResource {
     public Payload postDocuments(String project, Context context) {
         return wrapNeo4jAppCall(() -> {
             checkProjectAccess(project, context);
-            org.icij.datashare.Objects.IncrementalImportRequest incrementalImportRequest =
-                parseContext(context, org.icij.datashare.Objects.IncrementalImportRequest.class);
+            IncrementalImportRequest incrementalImportRequest = parseContext(
+                context, IncrementalImportRequest.class);
             return this.importDocuments(project, incrementalImportRequest);
         });
     }
@@ -216,8 +224,8 @@ public class Neo4jResource {
         return wrapNeo4jAppCall(() -> {
             checkProjectAccess(project, context);
             // TODO: this should throw a bad request when not parsed correcly...
-            org.icij.datashare.Objects.IncrementalImportRequest incrementalImportRequest =
-                parseContext(context, org.icij.datashare.Objects.IncrementalImportRequest.class);
+            IncrementalImportRequest incrementalImportRequest = parseContext(
+                context, IncrementalImportRequest.class);
             return this.importNamedEntities(project, incrementalImportRequest);
         });
     }
@@ -228,8 +236,7 @@ public class Neo4jResource {
         return wrapNeo4jAppCall(() -> {
             checkCheckLocal();
             checkProjectAccess(project, context);
-            org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest request = parseContext(
-                context, org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest.class);
+            Neo4jAppNeo4jCSVRequest request = parseContext(context, Neo4jAppNeo4jCSVRequest.class);
             return this.exportNeo4jCSVs(project, request);
         });
     }
@@ -239,8 +246,7 @@ public class Neo4jResource {
     public Payload postGraphDump(String project, Context context) {
         return wrapNeo4jAppCall(() -> {
             checkProjectAccess(project, context);
-            org.icij.datashare.Objects.DumpRequest request = parseContext(
-                context, org.icij.datashare.Objects.DumpRequest.class);
+            DumpRequest request = parseContext(context, DumpRequest.class);
             return this.dumpGraph(project, request);
         });
     }
@@ -249,9 +255,16 @@ public class Neo4jResource {
     public Payload postSortedGraphDump(String project, Context context) {
         return wrapNeo4jAppCall(() -> {
             checkProjectAccess(project, context);
-            org.icij.datashare.Objects.SortedDumpRequest request = parseContext(
-                context, org.icij.datashare.Objects.SortedDumpRequest.class);
+            SortedDumpRequest request = parseContext(context, SortedDumpRequest.class);
             return this.sortedDumpGraph(project, request);
+        });
+    }
+
+    @Get("/graphs/nodes/count?project=:project")
+    public Payload getGraphNodesCount(String project, Context context) {
+        return wrapNeo4jAppCall(() -> {
+            checkProjectAccess(project, context);
+            return this.client.graphNodesCount(project);
         });
     }
 
@@ -479,17 +492,16 @@ public class Neo4jResource {
         return created;
     }
 
-    protected org.icij.datashare.Objects.IncrementalImportResponse importDocuments(
-        String projectId,
-        org.icij.datashare.Objects.IncrementalImportRequest request
+    protected IncrementalImportResponse importDocuments(
+        String projectId, IncrementalImportRequest request
     ) {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
         return client.importDocuments(projectId, request);
     }
 
-    protected org.icij.datashare.Objects.IncrementalImportResponse importNamedEntities(
-        String projectId, org.icij.datashare.Objects.IncrementalImportRequest request
+    protected IncrementalImportResponse importNamedEntities(
+        String projectId, IncrementalImportRequest request
     ) {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
@@ -497,9 +509,7 @@ public class Neo4jResource {
     }
 
     //CHECKSTYLE.OFF: AbbreviationAsWordInName
-    protected InputStream exportNeo4jCSVs(
-        String projectId, org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest request
-    ) {
+    protected InputStream exportNeo4jCSVs(String projectId, Neo4jAppNeo4jCSVRequest request) {
         // TODO: the database should be chosen dynamically with the Mode (local vs. server) and
         //  the project
         checkExtensionProject(projectId);
@@ -507,8 +517,7 @@ public class Neo4jResource {
         // Define a temp dir
         Path exportDir = null;
         try {
-            org.icij.datashare.Objects.Neo4jCSVResponse res =
-                client.exportNeo4jCSVs(projectId, request);
+            Neo4jCSVResponse res = client.exportNeo4jCSVs(projectId, request);
             logger.info("Exported data from ES to neo4j, statistics: {}",
                 lazy(() -> MAPPER.writeValueAsString(res.metadata)));
             exportDir = Paths.get(res.path);
@@ -532,9 +541,9 @@ public class Neo4jResource {
     //CHECKSTYLE.ON: AbbreviationAsWordInName
 
     protected InputStream dumpGraph(
-        String projectId, org.icij.datashare.Objects.DumpRequest request
+        String projectId, DumpRequest request
     ) throws URISyntaxException, IOException, InterruptedException {
-        org.icij.datashare.Objects.Neo4jAppDumpRequest neo4jAppRequest = validateDumpRequest(
+        Neo4jAppDumpRequest neo4jAppRequest = validateDumpRequest(
             request);
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
@@ -542,15 +551,13 @@ public class Neo4jResource {
     }
 
     protected InputStream sortedDumpGraph(
-        String projectId, org.icij.datashare.Objects.SortedDumpRequest request
+        String projectId, SortedDumpRequest request
     ) throws URISyntaxException, IOException, InterruptedException {
         checkExtensionProject(projectId);
         checkNeo4jAppStarted();
         Statement statement = request.query.defaultQueryStatement(getDocumentNodesLimit());
-        org.icij.datashare.Objects.Neo4jAppDumpRequest neo4jAppRequest =
-            new org.icij.datashare.Objects.Neo4jAppDumpRequest(
-                request.format, statement.getCypher()
-            );
+        Neo4jAppDumpRequest neo4jAppRequest = new Neo4jAppDumpRequest(
+            request.format, statement.getCypher());
         return client.dumpGraph(projectId, neo4jAppRequest);
     }
 
@@ -609,8 +616,8 @@ public class Neo4jResource {
         }
     }
 
-    protected org.icij.datashare.Objects.Neo4jAppDumpRequest validateDumpRequest(
-        org.icij.datashare.Objects.DumpRequest request) {
+    protected Neo4jAppDumpRequest validateDumpRequest(
+        DumpRequest request) {
         String validated = null;
         if (isLocal()) {
             if (request.query != null) {
@@ -619,13 +626,13 @@ public class Neo4jResource {
         } else {
             long defaultLimit = getDocumentNodesLimit();
             if (request.query == null) {
-                validated = org.icij.datashare.Objects.DumpQuery.defaultQueryStatement(
+                validated = DumpQuery.defaultQueryStatement(
                     defaultLimit).getCypher();
             } else {
                 validated = request.query.asValidated(getDocumentNodesLimit()).getCypher();
             }
         }
-        return new org.icij.datashare.Objects.Neo4jAppDumpRequest(request.format, validated);
+        return new Neo4jAppDumpRequest(request.format, validated);
     }
 
     private boolean isLocal() {

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -15,6 +15,8 @@ import static org.icij.datashare.Objects.Neo4jAppNeo4jCSVRequest;
 import static org.icij.datashare.Objects.Neo4jCSVResponse;
 import static org.icij.datashare.Objects.SortedDumpRequest;
 import static org.icij.datashare.Objects.StartNeo4jAppRequest;
+import static org.icij.datashare.Objects.Task;
+import static org.icij.datashare.Objects.TaskError;
 import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
 import static org.icij.datashare.text.Project.isAllowed;
 
@@ -56,6 +58,8 @@ import net.codestory.http.annotations.Get;
 import net.codestory.http.annotations.Post;
 import net.codestory.http.annotations.Prefix;
 import net.codestory.http.errors.ForbiddenException;
+import net.codestory.http.errors.HttpException;
+import net.codestory.http.errors.UnauthorizedException;
 import net.codestory.http.payload.Payload;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.icij.datashare.user.User;
@@ -257,6 +261,15 @@ public class Neo4jResource {
             checkProjectAccess(project, context);
             SortedDumpRequest request = parseContext(context, SortedDumpRequest.class);
             return this.sortedDumpGraph(project, request);
+        });
+    }
+
+    @Get("/tasks/:taskId?project=:project")
+    public Payload getTask(String taskId, String project, Context context) {
+        return wrapNeo4jAppCall(() -> {
+            checkProjectAccess(project, context);
+            checkTaskAccess(taskId, project, context);
+            return task(taskId, project);
         });
     }
 
@@ -486,7 +499,7 @@ public class Neo4jResource {
     protected IncrementalImportResponse importDocuments(
         String projectId, IncrementalImportRequest request
     ) {
-        checkExtensionProject(projectId);
+        checkProject(projectId);
         checkNeo4jAppStarted();
         return client.importDocuments(projectId, request);
     }
@@ -494,16 +507,34 @@ public class Neo4jResource {
     protected IncrementalImportResponse importNamedEntities(
         String projectId, IncrementalImportRequest request
     ) {
-        checkExtensionProject(projectId);
+        checkProject(projectId);
         checkNeo4jAppStarted();
         return client.importNamedEntities(projectId, request);
+    }
+
+    protected Task task(String taskId, String projectId) {
+        checkProject(projectId);
+        checkNeo4jAppStarted();
+        return client.task(taskId, projectId);
+    }
+
+    protected <T> T taskResult(String taskId, String projectId, Class<T> clazz) {
+        checkProject(projectId);
+        checkNeo4jAppStarted();
+        return client.taskResult(taskId, projectId, clazz);
+    }
+
+    protected List<TaskError> taskErrors(String taskId, String projectId) {
+        checkProject(projectId);
+        checkNeo4jAppStarted();
+        return List.of(client.taskErrors(taskId, projectId));
     }
 
     //CHECKSTYLE.OFF: AbbreviationAsWordInName
     protected InputStream exportNeo4jCSVs(String projectId, Neo4jAppNeo4jCSVRequest request) {
         // TODO: the database should be chosen dynamically with the Mode (local vs. server) and
         //  the project
-        checkExtensionProject(projectId);
+        checkProject(projectId);
         checkNeo4jAppStarted();
         // Define a temp dir
         Path exportDir = null;
@@ -536,7 +567,7 @@ public class Neo4jResource {
     ) throws URISyntaxException, IOException, InterruptedException {
         Neo4jAppDumpRequest neo4jAppRequest = validateDumpRequest(
             request);
-        checkExtensionProject(projectId);
+        checkProject(projectId);
         checkNeo4jAppStarted();
         return client.dumpGraph(projectId, neo4jAppRequest);
     }
@@ -544,7 +575,7 @@ public class Neo4jResource {
     protected InputStream sortedDumpGraph(
         String projectId, SortedDumpRequest request
     ) throws URISyntaxException, IOException, InterruptedException {
-        checkExtensionProject(projectId);
+        checkProject(projectId);
         checkNeo4jAppStarted();
         Statement statement = request.query.defaultQueryStatement(getDocumentNodesLimit());
         Neo4jAppDumpRequest neo4jAppRequest = new Neo4jAppDumpRequest(
@@ -564,9 +595,12 @@ public class Neo4jResource {
             logger.error(
                 "internal error on the python app side {}", returned.getMessageWithTrace()
             );
-            return new Payload("application/problem+json", returned).withCode(500);
-        } catch (ForbiddenException e) {
-            return new Payload("application/problem+json", fromException(e)).withCode(403);
+            return new Payload("application/problem+json", returned).withCode(e.status);
+        } catch (HttpException e) {
+            return new Payload("application/problem+json", fromException(e))
+                .withCode(e.code());
+        } catch (ProjectNotInitialized e) {
+            return new Payload("application/problem+json", fromException(e)).withCode(503);
         } catch (HttpUtils.JacksonParseError e) {
             HttpUtils.HttpError returned = fromException(e);
             logger.error(returned.getMessageWithTrace());
@@ -588,22 +622,43 @@ public class Neo4jResource {
         }
     }
 
+    protected void checkTaskAccess(String taskId, String project, Context context)
+        throws UnauthorizedException {
+        if (!isServer()) {
+            return;
+        }
+        // TODO: in the future, check that the context user is that task user
+        throw new UnauthorizedException();
+    }
+
+
     protected void checkCheckLocal() {
         if (!isLocal()) {
             throw new ForbiddenException();
         }
     }
 
-    protected void checkExtensionProject(String candidateProject) {
+    protected void checkProject(String project) {
+        checkExtensionProject(project);
+        checkProjectInitialized(project);
+    }
+
+    protected void checkExtensionProject(String project) {
         if (!supportsNeo4jEnterprise()) {
             if (this.neo4jSingleProjectId != null) {
-                if (!Objects.equals(this.neo4jSingleProjectId, candidateProject)) {
-                    InvalidProjectError error = new InvalidProjectError(
-                        this.neo4jSingleProjectId, candidateProject);
+                if (!Objects.equals(this.neo4jSingleProjectId, project)) {
+                    InvalidProjectError error =
+                        new InvalidProjectError(this.neo4jSingleProjectId, project);
                     logger.error(error.getMessage());
                     throw error;
                 }
             }
+        }
+    }
+
+    protected void checkProjectInitialized(String project) {
+        if (!projects.contains(project)) {
+            throw new ProjectNotInitialized(project);
         }
     }
 
@@ -627,8 +682,17 @@ public class Neo4jResource {
     }
 
     private boolean isLocal() {
-        String mode = propertiesProvider.get("mode").orElse("SERVER");
+        String mode = getMode();
         return mode.equals("LOCAL") || mode.equals("EMBEDDED");
+    }
+
+    private boolean isServer() {
+        return getMode().equals("SERVER");
+    }
+
+
+    private String getMode() {
+        return propertiesProvider.get("mode").orElse("SERVER");
     }
 
     private long getDocumentNodesLimit() {
@@ -713,6 +777,14 @@ public class Neo4jResource {
                     + "' extension is setup to support project '"
                     + project
                     + "'");
+        }
+    }
+
+    static class ProjectNotInitialized extends HttpUtils.HttpError {
+        public static final String title = "Project Not Initialized";
+
+        public ProjectNotInitialized(String project) {
+            super(title, "Project \"" + project + "\" as not been initialized");
         }
     }
 

--- a/src/main/java/org/icij/datashare/Objects.java
+++ b/src/main/java/org/icij/datashare/Objects.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.icij.datashare.text.NamedEntity;
 import org.neo4j.cypherdsl.core.Cypher;
 import org.neo4j.cypherdsl.core.Node;
 import org.neo4j.cypherdsl.core.Relationship;
@@ -114,6 +115,20 @@ public class Objects {
             this.query = query;
         }
 
+    }
+
+    protected static class GraphNodesCount {
+        protected final long documents;
+        protected final Map<NamedEntity.Category, Long> namedEntities;
+
+        @JsonCreator
+        GraphNodesCount(
+            @JsonProperty("documents") Long documents,
+            @JsonProperty("namedEntities") Map<NamedEntity.Category, Long> namedEntities
+        ) {
+            this.documents = Optional.ofNullable(documents).orElse(0L);
+            this.namedEntities = Optional.ofNullable(namedEntities).orElse(Map.of());
+        }
     }
 
 

--- a/src/main/java/org/icij/datashare/Objects.java
+++ b/src/main/java/org/icij/datashare/Objects.java
@@ -117,20 +117,6 @@ public class Objects {
 
     }
 
-    protected static class GraphNodesCount {
-        protected final long documents;
-        protected final Map<NamedEntity.Category, Long> namedEntities;
-
-        @JsonCreator
-        GraphNodesCount(
-            @JsonProperty("documents") Long documents,
-            @JsonProperty("namedEntities") Map<NamedEntity.Category, Long> namedEntities
-        ) {
-            this.documents = Optional.ofNullable(documents).orElse(0L);
-            this.namedEntities = Optional.ofNullable(namedEntities).orElse(Map.of());
-        }
-    }
-
 
     protected static class IncrementalImportResponse {
         protected final long imported;

--- a/src/test/java/org/icij/datashare/Neo4jClientTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jClientTest.java
@@ -3,6 +3,7 @@ package org.icij.datashare;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.Objects.TaskStatus.DONE;
 import static org.icij.datashare.Objects.TaskType.FULL_IMPORT;
+import static org.icij.datashare.Objects.IncrementalImportRequest;
 import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
@@ -60,7 +61,9 @@ public class Neo4jClientTest {
             String body;
             String project = context.query().get("project");
             if (project != null && project.equals("myproject")) {
-                if (Objects.equals(context.request().content(), "{}")) {
+                IncrementalImportRequest req  = MAPPER.readValue(
+                    context.request().content(), IncrementalImportRequest.class);
+                if (req.query == null) {
                     body = "{\"imported\": 3,\"nodesCreated\": 3,\"relationshipsCreated\": 3}";
                 } else {
                     body = "{\"imported\": 3,\"nodesCreated\": 1,\"relationshipsCreated\": 1}";
@@ -226,7 +229,7 @@ public class Neo4jClientTest {
             assertThat(assertThrowsExactly(
                 Neo4jClient.Neo4jAppError.class,
                 () -> client.importDocuments("unknown", body)
-            ).getMessage()).isEqualTo("Bad Request\nDetail: Invalid project unknown");
+            ).getMessage()).isEqualTo("Not Found\nDetail: Invalid project unknown");
         }
 
         @Test
@@ -316,7 +319,7 @@ public class Neo4jClientTest {
             assertThat(assertThrowsExactly(
                 Neo4jClient.Neo4jAppError.class,
                 () -> client.importNamedEntities("unknown", body)
-            ).getMessage()).isEqualTo("Bad Request\nDetail: Invalid project unknown");
+            ).getMessage()).isEqualTo("Not Found\nDetail: Invalid project unknown");
         }
 
         @Test
@@ -385,7 +388,7 @@ public class Neo4jClientTest {
             assertThat(assertThrowsExactly(
                 Neo4jClient.Neo4jAppError.class,
                 () -> client.dumpGraph("unknown", body)
-            ).getMessage()).isEqualTo("Bad Request\nDetail: Invalid project unknown");
+            ).getMessage()).isEqualTo("Not Found\nDetail: Invalid project unknown");
         }
 
         @Test

--- a/src/test/java/org/icij/datashare/Neo4jClientTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jClientTest.java
@@ -1,13 +1,12 @@
 package org.icij.datashare;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.icij.datashare.Objects.IncrementalImportRequest;
 import static org.icij.datashare.Objects.TaskStatus.DONE;
 import static org.icij.datashare.Objects.TaskType.FULL_IMPORT;
-import static org.icij.datashare.Objects.IncrementalImportRequest;
 import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,7 +18,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.TimeZone;
 import net.codestory.http.Configuration;
 import net.codestory.http.Context;
@@ -61,7 +59,7 @@ public class Neo4jClientTest {
             String body;
             String project = context.query().get("project");
             if (project != null && project.equals("myproject")) {
-                IncrementalImportRequest req  = MAPPER.readValue(
+                IncrementalImportRequest req = MAPPER.readValue(
                     context.request().content(), IncrementalImportRequest.class);
                 if (req.query == null) {
                     body = "{\"imported\": 3,\"nodesCreated\": 3,\"relationshipsCreated\": 3}";
@@ -461,8 +459,7 @@ public class Neo4jClientTest {
                 routes -> routes.get("/tasks/:taskId/result", this::mockGetResult)
             );
             // When
-            List<Map<String, String>> result = client.taskResult(
-                "taskId", "myproject", List.class);
+            List<?> result = client.taskResult("taskId", "myproject", List.class);
 
             // Then
             assertThat(result.size()).isEqualTo(1);
@@ -470,7 +467,7 @@ public class Neo4jClientTest {
         }
 
         @Test
-        public void test_get_task_error() throws ParseException, JsonProcessingException {
+        public void test_get_task_error() throws ParseException {
             // Given
             neo4jApp.configure(
                 routes -> routes.get("/tasks/:taskId/errors", this::mockGetTaskErrors)

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -2,12 +2,14 @@ package org.icij.datashare;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.icij.datashare.TestUtils.assertJson;
+import static org.icij.datashare.json.JsonObjectMapper.MAPPER;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
@@ -48,7 +50,7 @@ public class Neo4jResourceTest {
 
         @Override
         protected void checkNeo4jAppStarted() {
-            logger.info(Neo4jResourceWithApp.class.getName() + " is always running");
+            logger.debug(Neo4jResourceWithApp.class.getName() + " is always running");
         }
 
     }
@@ -971,10 +973,11 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_get_task_result_on_cli_mode() {
+        public void test_get_task_result_on_cli_mode() throws JsonProcessingException {
             // Given
             String result = "hello world";
-            neo4jApp.configure(routes -> routes.get("/tasks/:id/result", (id, context) -> result));
+            neo4jApp.configure(routes -> routes.get("/tasks/:id/result",
+                (id, context) -> new Payload("application/json", MAPPER.writeValueAsString("hello world"))));
             // When
             String response = neo4jAppResource.taskResult("taskId", "foo-datashare", String.class);
             // Then

--- a/src/test/java/org/icij/datashare/Neo4jResourceTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
@@ -973,11 +972,12 @@ public class Neo4jResourceTest {
         }
 
         @Test
-        public void test_get_task_result_on_cli_mode() throws JsonProcessingException {
+        public void test_get_task_result_on_cli_mode() {
             // Given
             String result = "hello world";
             neo4jApp.configure(routes -> routes.get("/tasks/:id/result",
-                (id, context) -> new Payload("application/json", MAPPER.writeValueAsString("hello world"))));
+                (id, context) -> new Payload(
+                    "application/json", MAPPER.writeValueAsString("hello world"))));
             // When
             String response = neo4jAppResource.taskResult("taskId", "foo-datashare", String.class);
             // Then


### PR DESCRIPTION
# PR description

This PR updates the Java side of the extension with the work done in #101 so that tasks related operation (HTTP routes or CLI) can be built on the top of the `Neo4jResource`.

# Changes
## `src`
### Added
- replicated python objects into the java codebase `Task`, `TaskError`
- created the `TaskType` enum which will be used to define the task performed by the extension (only `FULL_IMPORT` for now)
- updated to the java `Neo4jClient` with task related methods
- implemented `neo4jResource.task`, `neo4jResource.taskResult`, `neo4jResource.taskErrors` which will be needed to build task related CLI and HTTP


### Changed
- refactored `Neo4jClient` configuration
- replaced `checkExtensionProject` by `checkProject` which will additionally check that the project has been initiliazed

## `neo4j-app`
### Fixed
- python service dumps dates in a ISO format compatible with java