### PR TITLE
chore: refactor `Neo4jClient` to avoid using a global `UnirestInstance`

### DIFF
--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -72,7 +72,7 @@ import org.slf4j.LoggerFactory;
 
 @Singleton
 @Prefix("/api/neo4j")
-public class Neo4jResource {
+public class Neo4jResource implements AutoCloseable {
     private final Repository repository;
     private static final String NEO4J_APP_BIN = "neo4j-app";
     private static final Path TMP_ROOT = Path.of(
@@ -754,6 +754,10 @@ public class Neo4jResource {
             .orElse(NEO4J_DEFAULT_DUMPED_DOCUMENTS);
     }
 
+    @Override
+    public void close() throws Exception {
+        this.client.close();
+    }
 
     static class KillPythonProcess implements Runnable {
         private final Neo4jResource resource;


### PR DESCRIPTION
# PR description
- [x] merge #106 

# PR description
Previously the `Neo4jClient` was using `Unirest.xxxxxxx` instead of wrapping a `UnirestInstance` instance.
This approaches caused test to be sometimes flaky when anything was happening to that single `UnirestInstance` instance (connection pool stop, disconnected or anything).

# Changes
## `src`
### Changed
- refactor `Neo4jClient` to wrap a `UnirestInstance` instance and avoid using a global `UnirestInstance`