### PR TITLE
fix: `neo4j` enterprise support

### DIFF
--- a/neo4j-app/neo4j_app/app/dependencies.py
+++ b/neo4j-app/neo4j_app/app/dependencies.py
@@ -233,6 +233,7 @@ async def migrate_app_db_enter(config: AppConfig):
     driver = lifespan_neo4j_driver()
     if config.force_migrations:
         # TODO: improve this as is could lead to race conditions...
+        logger.info("Deleting all previous migrations...")
         await delete_all_migrations(driver)
     await migrate_db_schemas(
         driver,

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -192,9 +192,9 @@ RETURN m as migration
 
 async def delete_all_migrations(driver: neo4j.AsyncDriver):
     query = f"""MATCH (m:{MIGRATION_NODE})
-DETACH DELETE m
-    """
-    await driver.execute_query(query)
+DETACH DELETE m"""
+    async with registry_db_session(driver) as sess:
+        await sess.run(query)
 
 
 async def retrieve_projects(neo4j_driver: neo4j.AsyncDriver) -> List[Project]:

--- a/neo4j-app/neo4j_app/core/neo4j/projects.py
+++ b/neo4j-app/neo4j_app/core/neo4j/projects.py
@@ -102,8 +102,8 @@ async def is_enterprise(neo4j_driver: neo4j.AsyncDriver) -> bool:
     global _IS_ENTERPRISE
     if _IS_ENTERPRISE is None:
         query = "CALL dbms.components() YIELD edition RETURN edition"
-        res, _, _ = await neo4j_driver.execute_query(query)
-        if not res:
-            raise ValueError("Failed to determine neo4j distribution")
-        _IS_ENTERPRISE = res[0]["edition"] != "community"
+        async with neo4j_driver.session(database=neo4j.SYSTEM_DATABASE) as sess:
+            res = await sess.run(query)
+            res = await res.single()
+        _IS_ENTERPRISE = res["edition"] != "community"
     return _IS_ENTERPRISE


### PR DESCRIPTION
# TODOs
- [ ] merge #101

# PR description
When in enterprise support the default community DB called `neo4j` doesn't necessarily exist. Checking for the enterprise support has to be performed against the `system` DB which exists in both distributions.

For the same reason when the neo4j driver dependency is created, the piing on the DB has to performed on that same DB

# Changes
## `neo4j-app`
### Fixed
- fixed ping and neo4j distribution detection when in enterprise distribution (using the `system` DB instead of the default DB)
