### PR TITLE
fix: export stream

### DIFF
--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -12,6 +12,7 @@ from .migrations.migrations import (
     migration_v_0_1_0_tx,
     migration_v_0_2_0_tx,
     migration_v_0_3_0_tx,
+    migration_v_0_4_0_tx,
 )
 
 V_0_1_0 = Migration(
@@ -29,7 +30,12 @@ V_0_3_0 = Migration(
     label="Create tasks indexes and constraints",
     migration_fn=migration_v_0_3_0_tx,
 )
-MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0]
+V_0_4_0 = Migration(
+    version="0.4.0",
+    label="Create document path and content type indexes",
+    migration_fn=migration_v_0_4_0_tx,
+)
+MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0]
 
 
 def get_neo4j_csv_reader(

--- a/neo4j-app/neo4j_app/core/neo4j/graphs.py
+++ b/neo4j-app/neo4j_app/core/neo4j/graphs.py
@@ -4,7 +4,6 @@ import neo4j
 
 from neo4j_app.constants import (
     DOC_NODE,
-    MIGRATION_NODE,
     NE_APPEARS_IN_DOC,
     NE_NODE,
 )
@@ -20,18 +19,16 @@ _GRAPHML_DUMP_CONFIG = {
 }
 
 _CYPHER_DUMP_CONFIG = {
+    "stream": True,
+    "writeNodeProperties": True,
     "format": "cypher-shell",
     "cypherFormat": "create",
-    "streamStatements": True,
-    "batchSize": 20000,
     "useOptimizations": {"type": "UNWIND_BATCH", "unwindBatchSize": 100},
 }
 
-_DEFAULT_DUMP_QUERY = f"""MATCH (node)
-OPTIONAL MATCH (d)-[r]-(other)
-WHERE NOT any(l IN labels(node) WHERE l = '{MIGRATION_NODE}')
-    AND NOT any(l IN labels(other) WHERE l = '{MIGRATION_NODE}')
-RETURN d, r, other
+_DEFAULT_DUMP_QUERY = """MATCH (node)
+OPTIONAL MATCH (node)-[r]-(other)
+RETURN *
 """
 
 

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
@@ -1,8 +1,10 @@
 import neo4j
 
 from neo4j_app.constants import (
+    DOC_CONTENT_TYPE,
     DOC_ID,
     DOC_NODE,
+    DOC_PATH,
     MIGRATION_NODE,
     MIGRATION_PROJECT,
     MIGRATION_VERSION,
@@ -36,6 +38,10 @@ async def migration_v_0_2_0_tx(tx: neo4j.AsyncTransaction):
 
 async def migration_v_0_3_0_tx(tx: neo4j.AsyncTransaction):
     await _create_task_index_and_constraints(tx)
+
+
+async def migration_v_0_4_0_tx(tx: neo4j.AsyncTransaction):
+    await _create_document_path_and_content_type_indexes(tx)
 
 
 async def _create_document_and_ne_id_unique_constraint_tx(tx: neo4j.AsyncTransaction):
@@ -116,3 +122,14 @@ REQUIRE (lock.{TASK_LOCK_TASK_ID}) IS UNIQUE"""
 FOR (lock:{TASK_LOCK_NODE})
 ON (lock.{TASK_LOCK_WORKER_ID})"""
     await tx.run(task_lock_worker_id_query)
+
+
+async def _create_document_path_and_content_type_indexes(tx: neo4j.AsyncTransaction):
+    doc_path_index = f"""CREATE INDEX index_document_path IF NOT EXISTS
+FOR (doc:{DOC_NODE})
+ON (doc.{DOC_PATH})"""
+    await tx.run(doc_path_index)
+    doc_content_type_index = f"""CREATE INDEX index_document_content_type IF NOT EXISTS
+FOR (doc:{DOC_NODE})
+ON (doc.{DOC_CONTENT_TYPE})"""
+    await tx.run(doc_content_type_index)

--- a/neo4j-app/neo4j_app/tests/app/test_graphs.py
+++ b/neo4j-app/neo4j_app/tests/app/test_graphs.py
@@ -51,10 +51,8 @@ RETURN data;
                     "storeNodeIds": False,
                 },
                 query_filter="""MATCH (node)
-OPTIONAL MATCH (d)-[r]-(other)
-WHERE NOT any(l IN labels(node) WHERE l = '_Migration')
-    AND NOT any(l IN labels(other) WHERE l = '_Migration')
-RETURN d, r, other
+OPTIONAL MATCH (node)-[r]-(other)
+RETURN *
 """,
             ),
         ),
@@ -68,10 +66,10 @@ YIELD cypherStatements
 RETURN cypherStatements;
 """,
                 config={
+                    "stream": True,
+                    "writeNodeProperties": True,
                     "format": "cypher-shell",
                     "cypherFormat": "create",
-                    "streamStatements": True,
-                    "batchSize": 20000,
                     "useOptimizations": {
                         "type": "UNWIND_BATCH",
                         "unwindBatchSize": 100,
@@ -90,20 +88,18 @@ YIELD cypherStatements
 RETURN cypherStatements;
 """,
                 config={
+                    "stream": True,
+                    "writeNodeProperties": True,
                     "format": "cypher-shell",
                     "cypherFormat": "create",
-                    "streamStatements": True,
-                    "batchSize": 20000,
                     "useOptimizations": {
                         "type": "UNWIND_BATCH",
                         "unwindBatchSize": 100,
                     },
                 },
                 query_filter="""MATCH (node)
-OPTIONAL MATCH (d)-[r]-(other)
-WHERE NOT any(l IN labels(node) WHERE l = '_Migration')
-    AND NOT any(l IN labels(other) WHERE l = '_Migration')
-RETURN d, r, other
+OPTIONAL MATCH (node)-[r]-(other)
+RETURN *
 """,
             ),
         ),
@@ -117,10 +113,10 @@ YIELD cypherStatements
 RETURN cypherStatements;
 """,
                 config={
+                    "stream": True,
+                    "writeNodeProperties": True,
                     "format": "cypher-shell",
                     "cypherFormat": "create",
-                    "streamStatements": True,
-                    "batchSize": 20000,
                     "useOptimizations": {
                         "type": "UNWIND_BATCH",
                         "unwindBatchSize": 100,

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -5,6 +5,7 @@ from neo4j_app.core.neo4j.migrations.migrations import (
     migration_v_0_1_0_tx,
     migration_v_0_2_0_tx,
     migration_v_0_3_0_tx,
+    migration_v_0_4_0_tx,
 )
 
 
@@ -67,3 +68,21 @@ async def test_migration_v_0_3_0_tx(neo4j_test_session: neo4j.AsyncSession):
     async for rec in constraints_res:
         existing_constraints.add(rec["name"])
     assert "constraint_task_unique_id" in existing_constraints
+
+
+@pytest.mark.asyncio
+async def test_migration_v_0_4_0_tx(neo4j_test_session: neo4j.AsyncSession):
+    # When
+    await neo4j_test_session.execute_write(migration_v_0_4_0_tx)
+
+    # Then
+    indexes_res = await neo4j_test_session.run("SHOW INDEXES")
+    existing_indexes = set()
+    async for rec in indexes_res:
+        existing_indexes.add(rec["name"])
+    expected_indexes = [
+        "index_document_path",
+        "index_document_content_type",
+    ]
+    for index in expected_indexes:
+        assert index in expected_indexes

--- a/plugins/neo4j-graph-widget/components/WidgetNeo4jGraph.vue
+++ b/plugins/neo4j-graph-widget/components/WidgetNeo4jGraph.vue
@@ -254,17 +254,6 @@ export default {
       await this.$neo4jCore.request(`/api/neo4j/init?project=${this.project}`, { method: 'POST' })
       this.$store.commit('neo4j/projectInit', { project: this.project, initialized: true })
     },
-    postDumpRequest(request) {
-      const config = {
-        method: 'POST',
-        data: request,
-        headers: {
-          "accept-encoding": "identity"
-        }
-      }
-      getFullUrl
-      return this.$neo4jCore.request(`/api/neo4j/graphs/dump?project=${this.project}`, config)
-    },
     async getFileTypes() {
       this.$wait.start('load all file types')
       this.fileTypes = await this.aggregate('contentType', 'contentType')

--- a/plugins/neo4j-graph-widget/core/CoreExtension.js
+++ b/plugins/neo4j-graph-widget/core/CoreExtension.js
@@ -51,10 +51,14 @@ export class CoreExtension {
     return response
   }
 
-
-  async request(url, config = {}) {
+  getFullUrl(url) {
     const Api = this.#core.api.constructor
     const fullUrl = Api.getFullUrl(url)
+    return fullUrl
+  }
+
+  async request(url, config = {}) {
+    const fullUrl = this.getFullUrl(url)
     try {
       const r = await fetch(fullUrl, {
         body: JSON.stringify(config.data),

--- a/plugins/neo4j-graph-widget/core/CoreExtension.js
+++ b/plugins/neo4j-graph-widget/core/CoreExtension.js
@@ -52,9 +52,7 @@ export class CoreExtension {
   }
 
   getFullUrl(url) {
-    const Api = this.#core.api.constructor
-    const fullUrl = Api.getFullUrl(url)
-    return fullUrl
+    return this.#core.api.constructor.getFullUrl(url)
   }
 
   async request(url, config = {}) {

--- a/src/main/java/org/icij/datashare/HttpUtils.java
+++ b/src/main/java/org/icij/datashare/HttpUtils.java
@@ -75,9 +75,10 @@ public class HttpUtils {
         }
     }
 
-    protected static <T> T parseContext(Context context, Class<T> clazz) throws JacksonParseError {
+    protected static <T> T parseRequestContent(String content, Class<T> clazz)
+        throws JacksonParseError {
         try {
-            return EXT_MAPPER.readValue(context.request().content(), clazz);
+            return EXT_MAPPER.readValue(content, clazz);
         } catch (IOException | IllegalArgumentException e) {
             throw new JacksonParseError("Failed to parse request", e);
         }

--- a/src/main/java/org/icij/datashare/Neo4jResource.java
+++ b/src/main/java/org/icij/datashare/Neo4jResource.java
@@ -496,8 +496,7 @@ public class Neo4jResource implements AutoCloseable {
     protected InputStream dumpGraph(
         String projectId, DumpRequest request
     ) throws URISyntaxException, IOException, InterruptedException {
-        Neo4jAppDumpRequest neo4jAppRequest = validateDumpRequest(
-            request);
+        Neo4jAppDumpRequest neo4jAppRequest = validateDumpRequest(request);
         checkProject(projectId);
         checkNeo4jAppStarted();
         return client.dumpGraph(projectId, neo4jAppRequest);

--- a/src/main/java/org/icij/datashare/Objects.java
+++ b/src/main/java/org/icij/datashare/Objects.java
@@ -118,6 +118,16 @@ public class Objects {
             this.query = query;
         }
 
+        String dumpExtension() {
+            switch (format) {
+                case CYPHER_SHELL:
+                    return ".dump";
+                case GRAPHML:
+                    return ".graphml";
+                default:
+                    throw new IllegalStateException("Unexpected value: " + format);
+            }
+        }
     }
 
     protected static class GraphCount {


### PR DESCRIPTION
# PR description

This PR fixes the export behavior of the graph. Previously the graph was streamed to the frontend but later put inside a `Blob` linked to a hidden button which was then clicked.
However to create the `Blob` the whole stream was consumed on the client side and hence the download started only after everything was read from the backend, which could be several minutes later.

The PR fixes this behavior by posting the dump request through an HTTP form opened in another blank tab (and without creating any `Blob`).

Additionnally the PR adds a few optimizations to make the export faster.

# Changes
## `plugins/neo4j-graph-widget`
### Changed
- changed `WidgetNeo4jGraph` to stream the dump by submitting on a hidden form which opens in new blank tab

## `neo4j-app`
### Added
- added indexes on `Document.path` and `Document.contentType` to make the export query faster


## `src`
### Changed
- adapted the `/POST /api/neo4j/graph/dump` API route to receive the `DumpRequest` wrapped into a object: `{"dumpRequest": {....}}` in order to be able to receive it as a JSON string posted through a form
