### PR TITLE
feature: add email addresses domain and user in neo4j the graph

### DIFF
--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -34,9 +34,11 @@ PROJECT_NODE = "_Project"
 
 # TODO: check that it the name retained in https://github.com/ICIJ/datashare/pull/1180
 EMAIL_CATEGORY = "EMAIL"
+EMAIL_DOMAIN = "emailDomain"
 EMAIL_HEADER = "emailHeaderField"
 EMAIL_RECEIVED_TYPE = "RECEIVED"
 EMAIL_SENT_TYPE = "SENT"
+EMAIL_USER = "emailUser"
 # TODO: check the naming here, we use "fields" here since the RFC specification
 #  https://www.rfc-editor.org/rfc/rfc2822 refers to this kind of header as fields, this
 #  is not very ubiquitous nor end user friendly. FTM and other knowledge base don't
@@ -46,6 +48,7 @@ EMAIL_REL_HEADER_FIELDS = "fields"
 EMAIL_REL_COLS = {
     EMAIL_REL_HEADER_FIELDS: {NEO4J_CSV_COL: "STRING[]"},
 }
+
 
 # TODO: check that this list is exhaustive, we know it isn't !!!
 SENT_EMAIL_HEADERS = {"tika_metadata_message_from", "tika_metadata_dc_creator"}

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -13,6 +13,7 @@ from .migrations.migrations import (
     migration_v_0_2_0_tx,
     migration_v_0_3_0_tx,
     migration_v_0_4_0_tx,
+    migration_v_0_5_0_tx,
 )
 
 V_0_1_0 = Migration(
@@ -35,7 +36,12 @@ V_0_4_0 = Migration(
     label="Create document path and content type indexes",
     migration_fn=migration_v_0_4_0_tx,
 )
-MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0]
+V_0_5_0 = Migration(
+    version="0.5.0",
+    label="Create email user and domain indexes",
+    migration_fn=migration_v_0_5_0_tx,
+)
+MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0, V_0_5_0]
 
 
 def get_neo4j_csv_reader(

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
@@ -5,6 +5,8 @@ from neo4j_app.constants import (
     DOC_ID,
     DOC_NODE,
     DOC_PATH,
+    EMAIL_DOMAIN,
+    EMAIL_USER,
     MIGRATION_NODE,
     MIGRATION_PROJECT,
     MIGRATION_VERSION,
@@ -42,6 +44,10 @@ async def migration_v_0_3_0_tx(tx: neo4j.AsyncTransaction):
 
 async def migration_v_0_4_0_tx(tx: neo4j.AsyncTransaction):
     await _create_document_path_and_content_type_indexes(tx)
+
+
+async def migration_v_0_5_0_tx(tx: neo4j.AsyncTransaction):
+    await _create_email_user_and_domain_indexes(tx)
 
 
 async def _create_document_and_ne_id_unique_constraint_tx(tx: neo4j.AsyncTransaction):
@@ -133,3 +139,15 @@ ON (doc.{DOC_PATH})"""
 FOR (doc:{DOC_NODE})
 ON (doc.{DOC_CONTENT_TYPE})"""
     await tx.run(doc_content_type_index)
+
+
+async def _create_email_user_and_domain_indexes(tx: neo4j.AsyncTransaction):
+    ne_email_user_index = f"""CREATE INDEX index_named_entity_email_user IF NOT EXISTS
+FOR (ne:{NE_NODE})
+ON (ne.{EMAIL_USER})"""
+    await tx.run(ne_email_user_index)
+    ne_email_domain_index = f"""
+CREATE INDEX index_named_entity_email_domain IF NOT EXISTS
+FOR (ne:{NE_NODE})
+ON (ne.{EMAIL_DOMAIN})"""
+    await tx.run(ne_email_domain_index)

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -6,6 +6,7 @@ from neo4j_app.core.neo4j.migrations.migrations import (
     migration_v_0_2_0_tx,
     migration_v_0_3_0_tx,
     migration_v_0_4_0_tx,
+    migration_v_0_5_0_tx,
 )
 
 
@@ -83,6 +84,24 @@ async def test_migration_v_0_4_0_tx(neo4j_test_session: neo4j.AsyncSession):
     expected_indexes = [
         "index_document_path",
         "index_document_content_type",
+    ]
+    for index in expected_indexes:
+        assert index in expected_indexes
+
+
+@pytest.mark.asyncio
+async def test_migration_v_0_5_0_tx(neo4j_test_session: neo4j.AsyncSession):
+    # When
+    await neo4j_test_session.execute_write(migration_v_0_5_0_tx)
+
+    # Then
+    indexes_res = await neo4j_test_session.run("SHOW INDEXES")
+    existing_indexes = set()
+    async for rec in indexes_res:
+        existing_indexes.add(rec["name"])
+    expected_indexes = [
+        "index_named_entity_email_user",
+        "index_named_entity_email_domain",
     ]
     for index in expected_indexes:
         assert index in expected_indexes


### PR DESCRIPTION
# TODO
- [x] merge #118

# Description

This PR adds the email domain and user to the graph nodes.

Email nodes will now look like: `:NAMED_ENTITY:EMAIL {mentionNorm: 'some-user@domain.com', emailUser: 'some-user', emailDomain: 'domain.com' , ...}`

The addition was done to let use build searches based on email domains / user names, which has been useful in the past.

# Changes
## `neo4j-app`
### Added
- added `emailUser` and `emailDomain` properties to the `EMAIL` nodes (also added indexes on these properties)
