### PR TITLE
fix: avoid crashing for inconsistent import batch and  buffer sizes

### DIFF
--- a/neo4j-app/neo4j_app/core/elasticsearch/client.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/client.py
@@ -241,9 +241,13 @@ class ESClientABC(metaclass=abc.ABCMeta):
             num_neo4j_workers,
             concurrency,
         )
-        queue_size = max_records_in_memory // import_batch_size
+        queue_size = max(max_records_in_memory // import_batch_size, 1)
         if not queue_size:
-            raise ValueError("import_batch_size must be >= max_records_in_memory")
+            msg = (
+                "import_batch_size must be < max_records_in_memory to leverage"
+                " neo4j concurrency"
+            )
+            logger.warning(msg)
         queue = asyncio.Queue(maxsize=queue_size)
 
         # Start the consumer tasks


### PR DESCRIPTION
# Changes

## `neo4j-app`
### Fixes
-  avoid crashing for inconsistent import batch and  buffer sizes and default to no neo4j concurrency in that case
