### PR TITLE
chore: improve Python process logging

### DIFF
--- a/neo4j-app/poetry.lock
+++ b/neo4j-app/poetry.lock
@@ -1224,6 +1224,17 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-json-logger"
+version = "2.0.7"
+description = "A python library adding a json log formatter"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "python-json-logger-2.0.7.tar.gz", hash = "sha256:23e7ec02d34237c5aa1e29a070193a4ea87583bb4e7f8fd06d3de8264c4b2e1c"},
+    {file = "python_json_logger-2.0.7-py3-none-any.whl", hash = "sha256:f380b826a991ebbe3de4d897aeec42760035ac760345e57b812938dc8b35e2bd"},
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.6"
 description = "A streaming multipart parser for Python"
@@ -1868,4 +1879,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "c535b93e188caca4cdf1f531f9269a1fc50bcdf1fe251e97d8fe7af9e04ac9aa"
+content-hash = "c1142f32778710fb02d7676aad1de0437c35c5201c56c26a129349b9fb457ee9"

--- a/neo4j-app/pyproject.toml
+++ b/neo4j-app/pyproject.toml
@@ -24,6 +24,7 @@ setuptools = "^67.6.1"
 datrie = "^0.8.2"
 tenacity = "^8.2.3"
 aiostream = "^0.5.1"
+python-json-logger = "^2.0.7"
 
 [tool.poetry.group.dev.dependencies]
 fastapi = { version = "^0.99.1", extras = ["all"] }

--- a/src/main/java/org/icij/datashare/Neo4jResourceCli.java
+++ b/src/main/java/org/icij/datashare/Neo4jResourceCli.java
@@ -24,14 +24,19 @@ public class Neo4jResourceCli extends Neo4jResource {
             String desc = option.get(2).toString();
             Object defaultValue = option.get(1);
             if (defaultValue instanceof String) {
-                String defaultAsString = (String) defaultValue;
-                if (!defaultAsString.isEmpty()) {
+                String value = (String) defaultValue;
+                if (!value.isEmpty()) {
                     parser.accepts(opt, desc).withRequiredArg().ofType(String.class)
                         .defaultsTo((String) defaultValue);
                 }
             } else if (defaultValue instanceof Integer) {
+                Integer value = (Integer) defaultValue;
                 parser.accepts(opt, desc).withRequiredArg().ofType(Integer.class)
-                    .defaultsTo((Integer) defaultValue);
+                    .defaultsTo(value);
+            } else if (defaultValue instanceof Boolean) {
+                Boolean value = (Boolean) defaultValue;
+                parser.accepts(opt, desc).withRequiredArg().ofType(Boolean.class)
+                    .defaultsTo(value);
             } else {
                 throw new IllegalArgumentException("Invalid default option " + option);
             }

--- a/src/test/java/org/icij/datashare/Neo4jResourceWebTest.java
+++ b/src/test/java/org/icij/datashare/Neo4jResourceWebTest.java
@@ -202,7 +202,13 @@ public class Neo4jResourceWebTest {
         }
     }
 
-    public static class BindNeo4jResourceEnterprise extends BindNeo4jResourceBase {
+    public static class BindNeo4jResourceWithPid extends BindNeo4jResource {
+        protected <T extends Neo4jResourceWeb> Class<T> getResourceClass() {
+            return (Class<T>) Neo4jResourceWithApp.class;
+        }
+    }
+
+    public static class BindNeo4jResourceEnterprise extends BindNeo4jResourceWithPid {
         @Override
         public void beforeAll(ExtensionContext extensionContext)
             throws InvocationTargetException, NoSuchMethodException, InstantiationException,
@@ -211,13 +217,6 @@ public class Neo4jResourceWebTest {
             Neo4jResource.supportNeo4jEnterprise = true;
         }
     }
-
-    public static class BindNeo4jResourceWithPid extends BindNeo4jResource {
-        protected <T extends Neo4jResourceWeb> Class<T> getResourceClass() {
-            return (Class<T>) Neo4jResourceWithApp.class;
-        }
-    }
-
 
     public static class MockNeo4jApp extends ProdWebServerRuleExtension
         implements BeforeAllCallback, AfterAllCallback {
@@ -946,12 +945,11 @@ public class Neo4jResourceWebTest {
         }
 
         @Test
-        public void test_check_extension_project_enterprise() {
+        public void  test_check_extension_project_enterprise() {
             // Given
             String project = "some-project";
             assertThat(project).isNotEqualTo(SINGLE_PROJECT);
             assertThat(Neo4jResource.supportNeo4jEnterprise).isEqualTo(true);
-            neo4jAppResource.startServerProcess(false);
 
             // When
             try {


### PR DESCRIPTION
# Description

Improve Python process logging.
Previously the Python process was not logging until the config was correctly loaded and the FastAPI server was up. This was preventing to log when:
- the config is wrong
- the FastAPI server failed to start (when any of the injected dependencies failed to be injected, neo4j not available for instance)

# Changes
## `neo4j-app`, `src`
## Added
- added the ability redirected Python process output to Java process output
- added the ability for the Python process to log in JSON format which should help log collection and analysis by tools such as Loki, DataDog and so on