### PR TITLE
fix: don't run linting test twice in CI

### DIFF
--- a/neo4j
+++ b/neo4j
@@ -654,7 +654,6 @@ Please run ./neo4j format"
         if _should_run_project "neo4j_app"; then
             cd "$ROOT_DIR"/neo4j-app
             # TODO: parallelize pytest...
-            _pytest linting_test.py
             # Here we expect the docker test images to be launched either by the user or the CI
             _pytest neo4j_app
 


### PR DESCRIPTION
# Changes
## `neo4j`
### Fixed
- remove linting tests from python tests (`./neo4j test -p neo4j_app`) as they are run with `./neo4j format_test -p neo4j_app`
