### PR TITLE
chore: automatically detect async tests

### DIFF
--- a/neo4j-app/neo4j_app/tests/app/test_admin.py
+++ b/neo4j-app/neo4j_app/tests/app/test_admin.py
@@ -2,7 +2,6 @@ import os
 import stat
 from pathlib import Path
 
-import pytest
 import pytest_asyncio
 from aiohttp.test_utils import TestClient
 
@@ -24,7 +23,6 @@ async def _populate_es(es_test_client_module: ESClient):
     await populate_es_with_doc_and_named_entities(es_test_client_module, n=10)
 
 
-@pytest.mark.asyncio
 async def test_post_named_entities_import_should_return_200(
     test_client_module: TestClient,
     _populate_es,

--- a/neo4j-app/neo4j_app/tests/app/test_graphs.py
+++ b/neo4j-app/neo4j_app/tests/app/test_graphs.py
@@ -30,7 +30,6 @@ async def _mocked_run(
     return _iter_records(lines, record_key)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "dump_format,record_key,query,expected_run_args",
     [
@@ -157,7 +156,6 @@ async def test_post_graph_dump_should_return_200(
         assert res.content == expected_output
 
 
-@pytest.mark.asyncio
 async def test_post_graph_dump_should_return_400_for_missing_database(
     test_client_module: TestClient,
 ):
@@ -175,7 +173,6 @@ async def test_post_graph_dump_should_return_400_for_missing_database(
     assert "field required" in error["detail"]
 
 
-@pytest.mark.asyncio
 async def test_post_graph_dump_should_return_400_for_invalid_dump_format(
     test_client_module: TestClient,
 ):

--- a/neo4j-app/neo4j_app/tests/app/test_projects.py
+++ b/neo4j-app/neo4j_app/tests/app/test_projects.py
@@ -1,5 +1,4 @@
 import neo4j
-import pytest
 from starlette.testclient import TestClient
 
 from neo4j_app.core.neo4j import V_0_1_0
@@ -19,7 +18,6 @@ def test_project_init_should_return_201(test_client: TestClient):
     assert res.status_code == 201
 
 
-@pytest.mark.asyncio
 async def test_project_init_should_return_200(
     test_client: TestClient, neo4j_test_driver: neo4j.AsyncDriver
 ):

--- a/neo4j-app/neo4j_app/tests/core/elasticsearch/test_client.py
+++ b/neo4j-app/neo4j_app/tests/core/elasticsearch/test_client.py
@@ -43,7 +43,6 @@ async def _mocked_search(*, body: Optional[Dict], index: Optional[str], size: in
     return {}
 
 
-@pytest.mark.asyncio
 async def test_es_client_should_search_with_pagination_size():
     # Given
     pagination = 666
@@ -58,7 +57,6 @@ async def test_es_client_should_search_with_pagination_size():
         mocked_search.assert_called_once_with(body=None, index=index, size=pagination)
 
 
-@pytest.mark.asyncio
 async def test_os_client_should_search_with_pagination_size():
     # Given
     pagination = 666
@@ -73,7 +71,6 @@ async def test_os_client_should_search_with_pagination_size():
         mocked_search.assert_called_once_with(body=None, index=index, size=pagination)
 
 
-@pytest.mark.asyncio
 async def test_es_client_should_raise_when_size_is_provided():
     # Given
     pagination = 666
@@ -88,7 +85,6 @@ async def test_es_client_should_raise_when_size_is_provided():
         await es_client.search(body=body, index=index, size=size)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query,concurrency,expected_num_lines",
     [
@@ -203,7 +199,6 @@ def _make_transport_error(error_code: int) -> TransportError:
     return TransportError(error_code, "", "")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "fail_at,max_retries,failure,raised",
     [

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
@@ -66,7 +66,6 @@ _MIGRATION_1 = Migration(
 )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "registry,expected_indexes,not_expected_indexes",
     [
@@ -117,7 +116,6 @@ async def test_migrate_db_schema(
         assert db_version == max_version
 
 
-@pytest.mark.asyncio
 async def test_migrate_db_schema_should_raise_after_timeout(
     _migration_index_and_constraint: neo4j.AsyncDriver,
     # pylint: disable=invalid-name
@@ -146,7 +144,6 @@ async def test_migrate_db_schema_should_raise_after_timeout(
         await migrate_db_schemas(neo4j_driver, registry, timeout_s=0, throttle_s=0.1)
 
 
-@pytest.mark.asyncio
 async def test_migrate_db_schema_should_wait_when_other_migration_in_progress(
     caplog,
     monkeypatch,
@@ -191,7 +188,6 @@ async def test_migrate_db_schema_should_wait_when_other_migration_in_progress(
     )
 
 
-@pytest.mark.asyncio
 async def test_migrate_db_schema_should_wait_when_other_migration_just_started(
     monkeypatch,
     caplog,
@@ -251,7 +247,6 @@ async def test_migrate_db_schema_should_wait_when_other_migration_just_started(
             await wipe_db(sess)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("enterprise", [True, False])
 async def test_retrieve_project_dbs(
     _migration_index_and_constraint: neo4j.AsyncDriver,
@@ -271,7 +266,6 @@ async def test_retrieve_project_dbs(
     assert projects == [Project(name=TEST_PROJECT)]
 
 
-@pytest.mark.asyncio
 async def test_migrate_should_use_registry_db_when_with_enterprise_support(
     _migration_index_and_constraint: neo4j.AsyncDriver,  # pylint: disable=invalid-name
     monkeypatch,
@@ -293,7 +287,6 @@ async def test_migrate_should_use_registry_db_when_with_enterprise_support(
         await migrate_db_schemas(neo4j_driver, registry, timeout_s=10, throttle_s=0.1)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("is_enterprise", [True, False])
 async def test_init_project(
     neo4j_test_driver: neo4j.AsyncDriver, is_enterprise: bool, monkeypatch
@@ -333,7 +326,6 @@ async def test_init_project(
         assert migration.version == V_0_1_0.version
 
 
-@pytest.mark.asyncio
 async def test_init_project_should_be_idempotent(neo4j_test_driver: neo4j.AsyncDriver):
     # Given
     neo4j_driver = neo4j_test_driver
@@ -363,7 +355,6 @@ async def test_init_project_should_be_idempotent(neo4j_test_driver: neo4j.AsyncD
     assert migration.version == V_0_1_0.version
 
 
-@pytest.mark.asyncio
 async def test_init_project_should_raise_for_reserved_name(
     neo4j_test_driver_session: neo4j.AsyncDriver,
 ):

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -1,5 +1,4 @@
 import neo4j
-import pytest
 
 from neo4j_app.core.neo4j.migrations.migrations import (
     migration_v_0_1_0_tx,
@@ -10,7 +9,6 @@ from neo4j_app.core.neo4j.migrations.migrations import (
 )
 
 
-@pytest.mark.asyncio
 async def test_migration_v_0_1_0_tx(
     neo4j_test_session: neo4j.AsyncSession,
 ):
@@ -25,7 +23,6 @@ async def test_migration_v_0_1_0_tx(
     assert "constraint_migration_unique_project_and_version" in existing_constraints
 
 
-@pytest.mark.asyncio
 async def test_migration_v_0_2_0_tx(
     neo4j_test_session: neo4j.AsyncSession,
 ):
@@ -46,7 +43,6 @@ async def test_migration_v_0_2_0_tx(
     assert "constraint_document_unique_id" in existing_constraints
 
 
-@pytest.mark.asyncio
 async def test_migration_v_0_3_0_tx(neo4j_test_session: neo4j.AsyncSession):
     # When
     await neo4j_test_session.execute_write(migration_v_0_3_0_tx)
@@ -71,7 +67,6 @@ async def test_migration_v_0_3_0_tx(neo4j_test_session: neo4j.AsyncSession):
     assert "constraint_task_unique_id" in existing_constraints
 
 
-@pytest.mark.asyncio
 async def test_migration_v_0_4_0_tx(neo4j_test_session: neo4j.AsyncSession):
     # When
     await neo4j_test_session.execute_write(migration_v_0_4_0_tx)
@@ -89,7 +84,6 @@ async def test_migration_v_0_4_0_tx(neo4j_test_session: neo4j.AsyncSession):
         assert index in expected_indexes
 
 
-@pytest.mark.asyncio
 async def test_migration_v_0_5_0_tx(neo4j_test_session: neo4j.AsyncSession):
     # When
     await neo4j_test_session.execute_write(migration_v_0_5_0_tx)

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_documents.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_documents.py
@@ -14,7 +14,6 @@ from neo4j_app.tests.conftest import (
 )
 
 
-@pytest.mark.asyncio
 async def test_write_neo4j_csv():
     # Given
 
@@ -49,7 +48,6 @@ ds/test_project/doc-2/doc-1,dirname-2
     assert csv == expected_csv
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("n_existing", list(range(3)))
 async def test_import_documents(
     neo4j_test_session: neo4j.AsyncSession, n_existing: int
@@ -88,7 +86,6 @@ RETURN count(*) as numDocs"""
     assert total_docs["numDocs"] == 3
 
 
-@pytest.mark.asyncio
 async def test_import_documents_should_update_document(
     neo4j_test_session: neo4j.AsyncSession,
 ):

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_graphs.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_graphs.py
@@ -50,7 +50,6 @@ CREATE (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrix);
     yield neo4j_test_driver_module
 
 
-@pytest.mark.asyncio
 async def test_dump_full_graph_to_graphml(_populate_neo4j: neo4j.AsyncDriver):
     # pylint: disable=invalid-name
     # Given
@@ -97,7 +96,6 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http\
     assert len(edges) == 1
 
 
-@pytest.mark.asyncio
 async def test_should_dump_subgraph_to_graphml(_populate_neo4j: neo4j.AsyncDriver):
     # pylint: disable=invalid-name
     # Given
@@ -145,7 +143,6 @@ xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http\
     assert names[0].text == "Keanu Reeves"
 
 
-@pytest.mark.asyncio
 async def test_should_dump_full_graph_to_cypher(_populate_neo4j: neo4j.AsyncDriver):
     # pylint: disable=invalid-name
     # Given
@@ -165,7 +162,6 @@ async def test_should_dump_full_graph_to_cypher(_populate_neo4j: neo4j.AsyncDriv
     assert 'properties:{born:1964, name:"Keanu Reeves"}}' in cypher_statements
 
 
-@pytest.mark.asyncio
 async def test_should_dump_subgraph_to_cypher(_populate_neo4j: neo4j.AsyncDriver):
     # pylint: disable=invalid-name
     # Given
@@ -191,7 +187,6 @@ RETURN person;
     assert 'properties:{born:1964, name:"Keanu Reeves"}}' in cypher_statements
 
 
-@pytest.mark.asyncio
 async def test_should_raise_for_invalid_dump_format(
     neo4j_test_driver_session: neo4j.AsyncDriver,
 ):
@@ -211,7 +206,6 @@ async def test_should_raise_for_invalid_dump_format(
             pass
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "n_docs,n_ents,expected_count",
     [

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_imports.py
@@ -26,7 +26,6 @@ CALL {
     return summary
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("num_workers", [1, 2])
 async def test_neo4_import_worker(
     num_workers: int, neo4j_test_driver: neo4j.AsyncDriver

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
@@ -22,7 +22,6 @@ async def _create_document(neo4j_test_session: neo4j.AsyncSession):
     return neo4j_test_session
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("n_existing", list(range(3)))
 async def test_import_named_entities(
     neo4j_test_session: neo4j.AsyncSession, n_existing: int
@@ -78,7 +77,6 @@ ORDER BY entLabels"""
     assert ents == expected_ents
 
 
-@pytest.mark.asyncio
 async def test_import_named_entities_should_update_named_entity(
     neo4j_test_session: neo4j.AsyncSession,
 ):
@@ -117,7 +115,6 @@ _MATCH_RECEIVED_EMAIL = (
 )
 
 
-@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "header_field,match_email_query",
     [
@@ -164,7 +161,6 @@ async def test_import_named_entity_rows_should_import_email_relationship(
     assert rel["fields"] == [header_field]
 
 
-@pytest.mark.asyncio()
 async def test_import_named_entity_rows_should_import_records_with_null_email_header(
     _create_document: neo4j.AsyncSession,
 ):
@@ -193,7 +189,6 @@ async def test_import_named_entity_rows_should_import_records_with_null_email_he
         )
 
 
-@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "header_field,match_email_query",
     [
@@ -242,7 +237,6 @@ CREATE (ne)-[:SENT { fields: ["someField"] }]->(doc)
     assert set(rel["fields"]) == {"someField", header_field}
 
 
-@pytest.mark.asyncio()
 @pytest.mark.parametrize(
     "mention_norm,expected_user,expected_domain",
     [

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_projects.py
@@ -1,11 +1,8 @@
 from unittest.mock import AsyncMock
 
-import pytest
-
 from neo4j_app.core.neo4j.projects import create_project_registry_db
 
 
-@pytest.mark.asyncio
 async def test_should_create_project_registry_db_with_enterprise_distribution(
     mock_enterprise,
 ):

--- a/neo4j-app/neo4j_app/tests/core/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/test_imports.py
@@ -118,7 +118,6 @@ async def _populate_es(
     yield es_client
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query,doc_type_field,expected_response",
     [
@@ -193,7 +192,6 @@ async def test_import_documents(
     assert response == expected_response
 
 
-@pytest.mark.asyncio
 async def test_import_documents_should_forward_project_db(
     watching_session_dbs: _WatchingSessionDbsDriver,
     mock_enterprise,  # pylint: disable=unused-argument
@@ -219,7 +217,6 @@ async def test_import_documents_should_forward_project_db(
     assert all(db == TEST_PROJECT for db in neo4j_driver.session_dbs)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "query,doc_type_field,expected_response",
     [
@@ -305,7 +302,6 @@ async def test_import_named_entities(
     assert response == expected_response
 
 
-@pytest.mark.asyncio
 async def test_should_aggregate_named_entities_attributes_on_relationship(
     _populate_es: ESClient,
     insert_docs_in_neo4j: neo4j.AsyncSession,
@@ -363,7 +359,6 @@ async def test_should_aggregate_named_entities_attributes_on_relationship(
     assert rels == expected_rels
 
 
-@pytest.mark.asyncio
 async def test_import_named_entities_should_forward_db(
     insert_docs_in_neo4j: neo4j.AsyncSession,
     watching_session_dbs: _WatchingSessionDbsDriver,
@@ -475,7 +470,6 @@ def _expected_ne_doc_rel_lines() -> str:
     return "\n".join(sorted(lines)) + "\n"
 
 
-@pytest.mark.asyncio
 async def test_to_neo4j_csvs(
     _populate_es: ESClient, neo4j_test_driver_session: neo4j.AsyncDriver, tmpdir
 ):
@@ -599,7 +593,6 @@ mentionIds:STRING[],offsets:LONG[],:START_ID,:END_ID(Document),:TYPE
     assert archive_dir.joinpath("bulk-import.sh").exists()
 
 
-@pytest.mark.asyncio
 async def test_to_neo4j_email_csvs(
     _populate_es: ESClient, neo4j_test_driver: neo4j.AsyncDriver, tmpdir
 ):
@@ -731,7 +724,6 @@ def test_neo4j_bulk_import_script(
     assert neo4j_cmd == expected_cmd
 
 
-@pytest.mark.asyncio
 async def test_to_neo4j_csvs_should_forward_project_db(
     _populate_es: ESClient,
     mock_enterprise,

--- a/neo4j-app/neo4j_app/tests/core/utils/test_asyncio.py
+++ b/neo4j-app/neo4j_app/tests/core/utils/test_asyncio.py
@@ -1,11 +1,9 @@
 import asyncio
 
-import pytest
 
 from neo4j_app.core.utils.asyncio import run_with_concurrency
 
 
-@pytest.mark.asyncio
 async def test_run_concurrently():
     # Given
     short = 0.001

--- a/neo4j-app/neo4j_app/tests/core/utils/test_progress.py
+++ b/neo4j-app/neo4j_app/tests/core/utils/test_progress.py
@@ -17,7 +17,6 @@ class MockProgress:
         self._progress.append(p)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "max_progress,raw,expected_progress",
     [
@@ -40,7 +39,6 @@ async def test_to_raw_progress(
     assert progress.progress == expected_progress
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "start,end,expected_progress",
     [
@@ -64,7 +62,6 @@ async def test_to_scaled_progress(
     assert progress.progress == expected_progress
 
 
-@pytest.mark.asyncio
 async def test_to_scaled_and_raw():
     # Given
     progress = MockProgress()

--- a/neo4j-app/neo4j_app/tests/icij_worker/task_manager/test_neo4j.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/task_manager/test_neo4j.py
@@ -73,7 +73,6 @@ RETURN task, result"""
     return list(zip(tasks, [None, None, r_2]))
 
 
-@pytest.mark.asyncio
 async def test_task_manager_get_task(
     neo4j_app_driver: neo4j.AsyncDriver, populate_tasks: List[Task]
 ):
@@ -103,7 +102,6 @@ async def test_task_manager_get_task(
     assert task == expected_task
 
 
-@pytest.mark.asyncio
 async def test_task_manager_get_completed_task(
     neo4j_app_driver: neo4j.AsyncDriver,
     _populate_results: List[Tuple[Task, List[TaskResult]]],
@@ -121,7 +119,6 @@ async def test_task_manager_get_completed_task(
     assert isinstance(task.completed_at, datetime)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "statuses,task_type,expected_ix",
     [
@@ -157,7 +154,6 @@ async def test_task_manager_get_tasks(
     assert tasks == expected_tasks
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "task_id,expected_errors",
     [
@@ -208,7 +204,6 @@ async def test_get_task_errors(
     assert retrieved_errors == expected_errors
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "task_id,expected_result",
     [
@@ -240,7 +235,6 @@ async def test_task_manager_get_task_result(
         assert result == expected_result
 
 
-@pytest.mark.asyncio
 async def test_task_manager_enqueue(neo4j_app_driver: neo4j.AsyncDriver):
     # Given
     project = TEST_PROJECT
@@ -262,7 +256,6 @@ async def test_task_manager_enqueue(neo4j_app_driver: neo4j.AsyncDriver):
     assert queued == expected
 
 
-@pytest.mark.asyncio
 async def test_task_manager_enqueue_should_raise_for_existing_task(
     neo4j_app_driver: neo4j.AsyncDriver,
 ):
@@ -283,7 +276,6 @@ async def test_task_manager_enqueue_should_raise_for_existing_task(
         await task_manager.enqueue(task, project)
 
 
-@pytest.mark.asyncio
 async def test_task_manager_cancel(neo4j_app_driver: neo4j.AsyncDriver):
     # Given
     project = TEST_PROJECT
@@ -302,7 +294,6 @@ async def test_task_manager_cancel(neo4j_app_driver: neo4j.AsyncDriver):
     assert task == expected
 
 
-@pytest.mark.asyncio
 async def test_task_manager_enqueue_should_raise_when_queue_full(
     neo4j_app_driver: neo4j.AsyncDriver,
 ):

--- a/neo4j-app/neo4j_app/tests/icij_worker/worker/event_publisher/test_neo4j.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/worker/event_publisher/test_neo4j.py
@@ -17,7 +17,6 @@ def publisher(neo4j_app_driver: neo4j.AsyncDriver) -> Neo4jEventPublisher:
     return worker
 
 
-@pytest.mark.asyncio
 async def test_worker_publish_event(
     populate_tasks: List[Task], publisher: Neo4jEventPublisher
 ):
@@ -48,7 +47,6 @@ async def test_worker_publish_event(
     assert saved_task == expected
 
 
-@pytest.mark.asyncio
 async def test_worker_publish_done_task_event_should_not_update_task(
     publisher: Neo4jEventPublisher,
 ):
@@ -82,7 +80,6 @@ async def test_worker_publish_done_task_event_should_not_update_task(
     assert saved_task == completed
 
 
-@pytest.mark.asyncio
 async def test_worker_publish_event_for_unknown_task(publisher: Neo4jEventPublisher):
     # This is useful when task is not reserved yet
     # Given
@@ -110,7 +107,6 @@ async def test_worker_publish_event_for_unknown_task(publisher: Neo4jEventPublis
     assert saved_task == expected
 
 
-@pytest.mark.asyncio
 async def test_worker_publish_event_should_use_status_resolution(
     populate_tasks: List[Task], publisher: Neo4jEventPublisher
 ):

--- a/neo4j-app/neo4j_app/tests/icij_worker/worker/test_neo4j.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/worker/test_neo4j.py
@@ -39,7 +39,6 @@ async def _count_locks(driver: neo4j.AsyncDriver, project: str) -> int:
     return counts["nLocks"]
 
 
-@pytest.mark.asyncio
 async def test_worker_consume_task(
     populate_tasks: List[Task], worker: Neo4jAsyncWorker
 ):
@@ -61,7 +60,6 @@ async def test_worker_consume_task(
     assert counts["nLocks"] == 1
 
 
-@pytest.mark.asyncio
 async def test_worker_negatively_acknowledge(
     populate_tasks: List[Task], worker: Neo4jAsyncWorker
 ):
@@ -80,7 +78,6 @@ async def test_worker_negatively_acknowledge(
     assert n_locks == 0
 
 
-@pytest.mark.asyncio
 async def test_worker_negatively_acknowledge_and_requeue(
     populate_tasks: List[Task], worker: Neo4jAsyncWorker
 ):
@@ -118,7 +115,6 @@ async def test_worker_negatively_acknowledge_and_requeue(
     assert n_locks == 0
 
 
-@pytest.mark.asyncio
 async def test_worker_save_result(populate_tasks: List[Task], worker: Neo4jAsyncWorker):
     # Given
     task_manager = Neo4JTaskManager(worker.driver, max_queue_size=10)
@@ -138,7 +134,6 @@ async def test_worker_save_result(populate_tasks: List[Task], worker: Neo4jAsync
     assert saved_result == task_result
 
 
-@pytest.mark.asyncio
 async def test_worker_should_raise_when_saving_existing_result(
     populate_tasks: List[Task], worker: Neo4jAsyncWorker
 ):
@@ -157,7 +152,6 @@ async def test_worker_should_raise_when_saving_existing_result(
         await worker.save_result(result=task_result, project=project)
 
 
-@pytest.mark.asyncio
 async def test_worker_save_error(populate_tasks: List[Task], worker: Neo4jAsyncWorker):
     # pylint: disable=unused-argument
     # Given
@@ -183,7 +177,6 @@ async def test_worker_save_error(populate_tasks: List[Task], worker: Neo4jAsyncW
     assert saved_errors == [error]
 
 
-@pytest.mark.asyncio
 async def test_worker_acknowledgment_cm(
     populate_tasks: List[Task], worker: Neo4jAsyncWorker
 ):

--- a/neo4j-app/neo4j_app/tests/icij_worker/worker/test_worker.py
+++ b/neo4j-app/neo4j_app/tests/icij_worker/worker/test_worker.py
@@ -46,7 +46,6 @@ def mock_failing_worker(test_failing_async_app: ICIJApp, tmpdir: Path) -> MockWo
 _TASK_DB = dict()
 
 
-@pytest.mark.asyncio
 async def test_task_wrapper_run_asyncio_task(mock_worker: MockWorker):
     # Given
     worker = mock_worker
@@ -103,7 +102,6 @@ async def test_task_wrapper_run_asyncio_task(mock_worker: MockWorker):
     assert saved_result == expected_result
 
 
-@pytest.mark.asyncio
 async def test_task_wrapper_run_sync_task(mock_worker: MockWorker):
     # Given
     worker = mock_worker
@@ -158,7 +156,6 @@ async def test_task_wrapper_run_sync_task(mock_worker: MockWorker):
     assert saved_result == expected_result
 
 
-@pytest.mark.asyncio
 async def test_task_wrapper_should_recover_from_recoverable_error(
     mock_failing_worker: MockWorker,
 ):
@@ -245,7 +242,6 @@ async def test_task_wrapper_should_recover_from_recoverable_error(
     assert events == expected_events
 
 
-@pytest.mark.asyncio
 async def test_task_wrapper_should_handle_non_recoverable_error(
     mock_failing_worker: MockWorker,
 ):
@@ -310,7 +306,6 @@ async def test_task_wrapper_should_handle_non_recoverable_error(
     assert error_event == expected_error_event
 
 
-@pytest.mark.asyncio
 async def test_task_wrapper_should_handle_unregistered_task(mock_worker: MockWorker):
     # Given
     worker = mock_worker
@@ -375,7 +370,6 @@ async def test_task_wrapper_should_handle_unregistered_task(mock_worker: MockWor
     assert error_event == expected_error_event
 
 
-@pytest.mark.asyncio
 async def test_work_once_should_not_run_cancelled_task(mock_worker: MockWorker, caplog):
     # Given
     worker = mock_worker
@@ -403,7 +397,6 @@ async def test_work_once_should_not_run_cancelled_task(mock_worker: MockWorker, 
     assert any(expected in m for m in caplog.messages)
 
 
-@pytest.mark.asyncio
 async def test_cancel_running_task(mock_worker: MockWorker):
     # Given
     worker = mock_worker

--- a/neo4j-app/pyproject.toml
+++ b/neo4j-app/pyproject.toml
@@ -13,6 +13,9 @@ exclude = ["neo4j_app/tests"]
 line-length = 88
 target = "py38"
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 fastapi = "^0.99.1"


### PR DESCRIPTION
# Changes
## Changed
- remove `@pytest.mark.asyncio` decorators in favor of global `pytest` asyncio configuration through `asyncio_mode = "auto"` in `tool.pytest.ini_options` of the `pyproject.toml`
