### PR TITLE
fix: re-running migrations

### DIFF
--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -242,7 +242,7 @@ async def migrate_project_db_schema(
     async with registry_db_session(neo4j_driver) as registry_sess:
         async with project_db_session(neo4j_driver, project=project) as project_sess:
             while "Waiting for DB to be migrated or for a timeout":
-                migrations = await project_sess.execute_read(
+                migrations = await registry_sess.execute_read(
                     project_migrations_tx, project=project
                 )
                 in_progress = [


### PR DESCRIPTION
# Bug descriptions

Migration are always rerunning at app startup because the list of already run migrations was not done from the proper DB

# Changes
## `neo4j-app`
### Fixed
- read already run migrations from the registry DB