### PR TITLE
chore: use bolt as neo4j URI scheme

### DIFF
--- a/.data/datashare.properties.template
+++ b/.data/datashare.properties.template
@@ -47,5 +47,6 @@ esMaxConcurrency=20
 neo4jStartServerCmd=
 neo4jAppStartTimeoutS=80
 neo4jUser=neo4j
+neo4jUriScheme=bolt
 neo4jPassword=changeme
 neo4jCliTaskPollIntervalS=2


### PR DESCRIPTION
# Changes
## `.data`
### Changed
- use `bolt` as neo4j URI scheme for development as neo4j is not running in a cluster