### PR TITLE
feature: add document nodes create at and modified at attributes

### DIFF
--- a/neo4j-app/neo4j_app/app/tasks.py
+++ b/neo4j-app/neo4j_app/app/tasks.py
@@ -31,14 +31,14 @@ def tasks_router() -> APIRouter:
 
     @router.post("/tasks", response_model=Task)
     async def _create_task(project: str, job: TaskJob) -> Response:
-        task_task_manager = lifespan_task_manager()
+        task_manager = lifespan_task_manager()
         event_publisher = lifespan_event_publisher()
         task_id = job.task_id
         if task_id is None:
             task_id = job.generate_task_id()
         task = job.to_task(task_id=task_id)
         try:
-            await task_task_manager.enqueue(task, project)
+            await task_manager.enqueue(task, project)
         except TaskAlreadyExists:
             return Response(task.id, status_code=200)
         except TaskQueueIsFull as e:
@@ -55,9 +55,9 @@ def tasks_router() -> APIRouter:
 
     @router.post("/tasks/{task_id}/cancel", response_model=Task)
     async def _cancel_task(project: str, task_id: str) -> Task:
-        task_task_manager = lifespan_task_manager()
+        task_manager = lifespan_task_manager()
         try:
-            cancelled = await task_task_manager.cancel(task_id=task_id, project=project)
+            cancelled = await task_manager.cancel(task_id=task_id, project=project)
         except UnknownTask as e:
             raise HTTPException(status_code=404, detail=e.args[0]) from e
         return cancelled

--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -6,10 +6,13 @@ NEO4J_CSV_COL = "node_col"
 DOC_NODE = "Document"
 DOC_CONTENT_LENGTH = "contentLength"
 DOC_CONTENT_TYPE = "contentType"
+DOC_CREATED_AT = "createdAt"
 DOC_DIRNAME = "dirname"
 DOC_ID = "id"
 DOC_ID_CSV = f"ID({DOC_NODE})"
 DOC_EXTRACTION_DATE = "extractionDate"
+DOC_METADATA = "metadata"
+DOC_MODIFIED_AT = "modifiedAt"
 DOC_PATH = "path"
 DOC_URL_SUFFIX = "urlSuffix"
 DOC_ROOT_ID = "rootDocument"
@@ -20,11 +23,29 @@ DOC_COLUMNS = {
     DOC_CONTENT_TYPE: {},
     DOC_CONTENT_LENGTH: {NEO4J_CSV_COL: "LONG"},
     DOC_EXTRACTION_DATE: {NEO4J_CSV_COL: "DATETIME"},
+    DOC_METADATA: {},
     DOC_PATH: {},
     DOC_URL_SUFFIX: {},
 }
 
 DOC_ES_SOURCES = list(DOC_COLUMNS) + ["join", DOC_ROOT_ID]
+
+# Order matters here, we're taking the cdterms create in priority to be consistent
+# with datashare-api which sets the creationDate as from tika_metadata_dcterms_created
+# we fall back to other metadata if this one is missing
+DOC_CREATED_AT_META = [
+    "tika_metadata_dcterms_created_iso8601",
+    "tika_metadata_creation_date_iso8601",
+    "tika_metadata_date_iso8601",
+]
+DOC_MODIFIED_AT_META = [
+    "tika_metadata_dcterms_modified_iso8601",
+    "tika_metadata_last_modified_iso8601",
+    "tika_metadata_modified_iso8601",
+    "tika_metadata_last_save_date_iso8601",
+    "tika_metadata_pdf_docinfo_modified_iso8601",
+    "tika_metadata_date_iso8601",
+]
 
 PROJECT_RUNS_MIGRATION = "_RUNS"
 PROJECT_NAME = "name"

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -15,6 +15,7 @@ from .migrations.migrations import (
     migration_v_0_4_0_tx,
     migration_v_0_5_0_tx,
     migration_v_0_6_0_tx,
+    migration_v_0_7_0_tx,
 )
 
 V_0_1_0 = Migration(
@@ -47,7 +48,12 @@ V_0_6_0 = Migration(
     label="Add mention counts to named entity document relationships",
     migration_fn=migration_v_0_6_0_tx,
 )
-MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0, V_0_5_0, V_0_6_0]
+V_0_7_0 = Migration(
+    version="0.7.0",
+    label="Create document modified and created at indexes",
+    migration_fn=migration_v_0_7_0_tx,
+)
+MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0, V_0_5_0, V_0_6_0, V_0_7_0]
 
 
 def get_neo4j_csv_reader(

--- a/neo4j-app/neo4j_app/core/neo4j/documents.py
+++ b/neo4j-app/neo4j_app/core/neo4j/documents.py
@@ -6,9 +6,13 @@ import neo4j
 from neo4j_app.constants import (
     DOC_CONTENT_LENGTH,
     DOC_CONTENT_TYPE,
+    DOC_CREATED_AT,
+    DOC_CREATED_AT_META,
     DOC_DIRNAME,
     DOC_EXTRACTION_DATE,
     DOC_ID,
+    DOC_MODIFIED_AT,
+    DOC_MODIFIED_AT_META,
     DOC_NODE,
     DOC_PATH,
     DOC_ROOT_ID,
@@ -18,6 +22,15 @@ from neo4j_app.constants import (
 from neo4j_app.typing_ import LightCounters
 
 logger = logging.getLogger(__name__)
+
+
+_DOC_CREATED_AT_META = ["metadata." + c for c in DOC_CREATED_AT_META]
+_DOC_MODIFIED_AT_META = ["metadata." + c for c in DOC_MODIFIED_AT_META]
+
+
+def _coalesce(*, variable: str, attributes: List[str]) -> str:
+    values = ", ".join(f"{variable}.{a}" for a in attributes)
+    return f"coalesce({values})"
 
 
 async def import_document_rows(
@@ -37,7 +50,11 @@ CALL {{
         doc.{DOC_EXTRACTION_DATE} = datetime(row.{DOC_EXTRACTION_DATE}),
         doc.{DOC_DIRNAME} = row.{DOC_DIRNAME},
         doc.{DOC_PATH} = row.{DOC_PATH},
-        doc.{DOC_URL_SUFFIX} = row.{DOC_URL_SUFFIX} 
+        doc.{DOC_URL_SUFFIX} = row.{DOC_URL_SUFFIX},
+        doc.{DOC_CREATED_AT} = datetime({
+    _coalesce(variable="row", attributes=_DOC_CREATED_AT_META)}), 
+        doc.{DOC_MODIFIED_AT} = datetime({
+    _coalesce(variable="row", attributes=_DOC_MODIFIED_AT_META)}) 
     WITH doc, row
     WHERE doc.{DOC_ID} = row.{DOC_ID} and row.{DOC_ROOT_ID} IS NOT NULL
     MERGE (root:{DOC_NODE} {{{DOC_ID}: row.{DOC_ROOT_ID}}})

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrations.py
@@ -2,7 +2,9 @@ import neo4j
 
 from neo4j_app.constants import (
     DOC_CONTENT_TYPE,
+    DOC_CREATED_AT,
     DOC_ID,
+    DOC_MODIFIED_AT,
     DOC_NODE,
     DOC_PATH,
     EMAIL_DOMAIN,
@@ -55,6 +57,10 @@ async def migration_v_0_5_0_tx(tx: neo4j.AsyncTransaction):
 
 async def migration_v_0_6_0_tx(tx: neo4j.AsyncTransaction):
     await _add_mention_count_to_named_entity_relationship(tx)
+
+
+async def migration_v_0_7_0_tx(tx: neo4j.AsyncTransaction):
+    await _create_document_created_and_modified_at_indexes(tx)
 
 
 async def _create_document_and_ne_id_unique_constraint_tx(tx: neo4j.AsyncTransaction):
@@ -164,3 +170,14 @@ async def _add_mention_count_to_named_entity_relationship(tx: neo4j.AsyncTransac
     query = f"""MATCH (:{NE_NODE})-[rel:{NE_APPEARS_IN_DOC}]->(:{DOC_NODE})
 SET rel.{NE_MENTION_COUNT} = size(rel.{NE_OFFSETS})"""
     await tx.run(query)
+
+
+async def _create_document_created_and_modified_at_indexes(tx: neo4j.AsyncTransaction):
+    created_at_index = f"""CREATE INDEX index_document_created_at IF NOT EXISTS
+FOR (doc:{DOC_NODE})
+ON (doc.{DOC_CREATED_AT})"""
+    await tx.run(created_at_index)
+    modified_at_index = f"""CREATE INDEX index_document_modified_at IF NOT EXISTS
+FOR (doc:{DOC_NODE})
+ON (doc.{DOC_MODIFIED_AT})"""
+    await tx.run(modified_at_index)

--- a/neo4j-app/neo4j_app/tests/app/test_tasks.py
+++ b/neo4j-app/neo4j_app/tests/app/test_tasks.py
@@ -176,7 +176,7 @@ def test_create_task_should_return_429_when_too_many_tasks(
 
     # Then
     assert res_0.status_code == 201, res_0.json()
-    # This one is queued or rejected depending if the first one is processed or still
+    # This one is queued or rejected depending on if the first one is processed or still
     # in the queue
     assert res_1.status_code in [201, 429], res_1.json()
     assert res_2.status_code == 429, res_1.json()

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
@@ -376,7 +376,7 @@ async def test_init_project_should_raise_for_reserved_name(
         )
 
 
-@pytest.mark.regression("131")
+@pytest.mark.pull("131")
 async def test_migrate_project_db_schema_should_read_migrations_from_registry(
     neo4j_test_driver_session: neo4j.AsyncDriver,
     monkeypatch,

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -7,6 +7,7 @@ from neo4j_app.core.neo4j.migrations.migrations import (
     migration_v_0_4_0_tx,
     migration_v_0_5_0_tx,
     migration_v_0_6_0_tx,
+    migration_v_0_7_0_tx,
 )
 
 
@@ -116,3 +117,20 @@ async def test_migration_v_0_6_0_tx(neo4j_test_session: neo4j.AsyncSession):
     rel = res["rel"]
     mention_counts = rel.get("mentionCount")
     assert mention_counts == 2
+
+
+async def test_migration_v_0_7_0_tx(neo4j_test_session: neo4j.AsyncSession):
+    # When
+    await neo4j_test_session.execute_write(migration_v_0_7_0_tx)
+
+    # Then
+    indexes_res = await neo4j_test_session.run("SHOW INDEXES")
+    existing_indexes = set()
+    async for rec in indexes_res:
+        existing_indexes.add(rec["name"])
+    expected_indexes = [
+        "index_document_created_at",
+        "index_document_modified_at",
+    ]
+    for index in expected_indexes:
+        assert index in expected_indexes

--- a/neo4j-app/neo4j_app/tests/core/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/test_imports.py
@@ -91,7 +91,7 @@ async def _populate_es(
     index_name = TEST_PROJECT
     n = 20
     # Index some Documents
-    async for _ in index_docs(es_client, n=n):
+    async for _ in index_docs(es_client, n=n, add_dates=True):
         pass
     # Index entities
     async for _ in index_named_entities(es_client, n=n):
@@ -515,19 +515,19 @@ async def test_to_neo4j_csvs(
 
     expected_doc_header = """\
 id:ID(Document),dirname,contentType,contentLength:LONG,extractionDate:DATETIME,path,\
-urlSuffix,:LABEL
+urlSuffix,createdAt:DATETIME,modifiedAt:DATETIME,:LABEL
 """
     doc_nodes_header_path = archive_dir / doc_nodes_export.header_path
     assert_content(doc_nodes_header_path, expected_doc_header)
 
     expected_doc_nodes = """doc-0,dirname-0,content-type-0,0,2023-02-06T13:48:22.3866,\
-dirname-0,ds/test_project/doc-0/doc-0,Document
+dirname-0,ds/test_project/doc-0/doc-0,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
 doc-1,dirname-1,content-type-1,1,2023-02-06T13:48:22.3866,dirname-1,\
-ds/test_project/doc-1/doc-0,Document
+ds/test_project/doc-1/doc-0,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
 doc-3,dirname-3,content-type-3,9,2023-02-06T13:48:22.3866,dirname-3,\
-ds/test_project/doc-3/doc-2,Document
+ds/test_project/doc-3/doc-2,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
 doc-6,dirname-6,content-type-6,36,2023-02-06T13:48:22.3866,dirname-6,\
-ds/test_project/doc-6/doc-5,Document
+ds/test_project/doc-6/doc-5,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
 """
     doc_root_rels_path = archive_dir / doc_nodes_export.node_paths[0]
     assert_content(doc_root_rels_path, expected_doc_nodes, sort_lines=True)

--- a/neo4j-app/pyproject.toml
+++ b/neo4j-app/pyproject.toml
@@ -15,6 +15,9 @@ target = "py39"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "pull",
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
# TODO:
- [x] merge #136

# PR description

Adding document nodes `createdAt` and `modifiedAt` attributes (attribute names chosen to match the follow the money schema). These attributes are read from ES document metadata.

While reading the ES metadata, we look for the DC terms created/modified metadata in priority since it's the one used in the `datashare-api` to define the `Docuemnt.getCreationDate()` (`tika_metadata_dcterms_modified`).  In case these metadata are not found we fallback to other tika metadata.

The fallback order to creation date is : 
- `tika_metadata_dcterms_created_iso8601`
- `tika_metadata_creation_date_iso8601`
- `tika_metadata_date_iso8601` 

for modification date it is:
- `tika_metadata_dcterms_modified_iso8601`
- `tika_metadata_last_modified_iso8601`
- `tika_metadata_modified_iso8601`
- `tika_metadata_last_save_date_iso8601`
- `tika_metadata_pdf_docinfo_modified_iso8601`
- `tika_metadata_date_iso8601`


# Changes
## `neo4j-app`
### Added
- updated the regular and admin imports to add `createdAt` and `modifiedAt` attributes to the `Document` nodes
- added a indexes to `Document` nodes to be looked up and sorted by `createdAt` and `modifiedAt` dates