### PR TITLE
fix: support explicit transactions in migrations and fix mention count

### DIFF
--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -14,7 +14,7 @@ from .migrations.migrations import (
     migration_v_0_3_0_tx,
     migration_v_0_4_0_tx,
     migration_v_0_5_0_tx,
-    migration_v_0_6_0_tx,
+    migration_v_0_6_0,
     migration_v_0_7_0_tx,
 )
 
@@ -46,7 +46,7 @@ V_0_5_0 = Migration(
 V_0_6_0 = Migration(
     version="0.6.0",
     label="Add mention counts to named entity document relationships",
-    migration_fn=migration_v_0_6_0_tx,
+    migration_fn=migration_v_0_6_0,
 )
 V_0_7_0 = Migration(
     version="0.7.0",

--- a/neo4j-app/neo4j_app/core/neo4j/named_entities.py
+++ b/neo4j-app/neo4j_app/core/neo4j/named_entities.py
@@ -94,7 +94,7 @@ CALL {{
             rel.{NE_EXTRACTORS} = apoc.coll.toSet(\
                 rel.{NE_EXTRACTORS} + row.{NE_EXTRACTOR}),
             rel.{NE_OFFSETS} = apoc.coll.toSet(rel.{NE_OFFSETS} + row.{NE_OFFSETS})
-    SET rel.{NE_MENTION_COUNT} = size(rel.{NE_OFFSETS}) 
+    SET rel.{NE_MENTION_COUNT} = size(rel.{NE_IDS}) 
     WITH mention, doc, row
     CALL apoc.do.case(
         [

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrate.py
@@ -49,18 +49,28 @@ async def _create_indexes_tx(tx: neo4j.AsyncTransaction):
     await tx.run(index_query_1)
 
 
+async def _create_indexes(sess: neo4j.AsyncSession):
+    index_query_0 = "CREATE INDEX index0 IF NOT EXISTS FOR (n:Node) ON (n.attribute0)"
+    await sess.run(index_query_0)
+    index_query_1 = "CREATE INDEX index1 IF NOT EXISTS FOR (n:Node) ON (n.attribute1)"
+    await sess.run(index_query_1)
+
+
 async def _drop_constraint_tx(tx: neo4j.AsyncTransaction):
     drop_index_query = "DROP INDEX index0 IF EXISTS"
     await tx.run(drop_index_query)
 
 
-# noinspection PyTypeChecker
 _MIGRATION_0 = Migration(
     version="0.2.0",
     label="create index and constraint",
     migration_fn=_create_indexes_tx,
 )
-# noinspection PyTypeChecker
+_MIGRATION_0_EXPLICIT = Migration(
+    version="0.2.0",
+    label="create index and constraint",
+    migration_fn=_create_indexes,
+)
 _MIGRATION_1 = Migration(
     version="0.3.0",
     label="drop constraint",
@@ -75,6 +85,8 @@ _MIGRATION_1 = Migration(
         ([], set(), set()),
         # Single
         ([_MIGRATION_0], {"index0", "index1"}, set()),
+        # Single as explicit_transaction
+        ([_MIGRATION_0_EXPLICIT], {"index0", "index1"}, set()),
         # Multiple ordered
         ([_MIGRATION_0, _MIGRATION_1], {"index1"}, {"index0"}),
         # Multiple unordered

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -6,7 +6,7 @@ from neo4j_app.core.neo4j.migrations.migrations import (
     migration_v_0_3_0_tx,
     migration_v_0_4_0_tx,
     migration_v_0_5_0_tx,
-    migration_v_0_6_0_tx,
+    migration_v_0_6_0,
     migration_v_0_7_0_tx,
 )
 
@@ -105,11 +105,11 @@ async def test_migration_v_0_5_0_tx(neo4j_test_session: neo4j.AsyncSession):
 
 async def test_migration_v_0_6_0_tx(neo4j_test_session: neo4j.AsyncSession):
     # Given
-    create_path = """CREATE (:NamedEntity)-[:APPEARS_IN {offsets: [0, 1]}
+    create_path = """CREATE (:NamedEntity)-[:APPEARS_IN {mentionIds: ['id-0', 'id-1']}
 ]->(:Document)"""
     await neo4j_test_session.run(create_path)
     # When
-    await neo4j_test_session.execute_write(migration_v_0_6_0_tx)
+    await migration_v_0_6_0(neo4j_test_session)
     # Then
     match_path = "MATCH  (:NamedEntity)-[rel:APPEARS_IN]->(:Document) RETURN rel"
     res = await neo4j_test_session.run(match_path)

--- a/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/test_name_entities.py
@@ -85,7 +85,9 @@ async def test_import_named_entities_should_update_named_entity(
     transaction_batch_size = 3
     ents = list(make_named_entities(n=num_ents))
     query = """
-CREATE (n:NamedEntity {id: 'named-entity-0', offsets: [1, 2], documentId: 'doc-0'})
+CREATE (n:NamedEntity { 
+    id: 'named-entity-0', mentionIds: ['id-0', 'id-1'], documentId: 'doc-0'
+})
 """
     await neo4j_test_session.run(query)
 
@@ -104,7 +106,11 @@ RETURN ent as ent"""
     res = await neo4j_test_session.run(query)
     ent = await res.single()
     ent = dict(ent["ent"])
-    expected_ent = {"id": "named-entity-0", "offsets": [1, 2], "documentId": "doc-0"}
+    expected_ent = {
+        "id": "named-entity-0",
+        "mentionIds": ["id-0", "id-1"],
+        "documentId": "doc-0",
+    }
     assert ent == expected_ent
 
 

--- a/neo4j-app/neo4j_app/tests/core/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/test_imports.py
@@ -352,7 +352,7 @@ async def test_should_aggregate_named_entities_attributes_on_relationship(
             "offsets": [0, 1, 2],
             "mentionExtractors": ["core-nlp", "spacy"],
             "mentionIds": ["named-entity-1", "named-entity-2"],
-            "mentionCount": 3,
+            "mentionCount": 2,
             "extractorLanguage": "en",
         },
     ]


### PR DESCRIPTION
# Changes
## `neo4j-app`
### Added
- added the ability to use explicit transactions as migrations
### Fixed
- compute `NamedEntity.mentionCount` based on `mentionIds` instead of `offsets`
