### PR TITLE
feature: add titles to documents

### DIFF
--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -11,20 +11,24 @@ DOC_DIRNAME = "dirname"
 DOC_ID = "id"
 DOC_ID_CSV = f"ID({DOC_NODE})"
 DOC_EXTRACTION_DATE = "extractionDate"
+DOC_EXTRACTION_LEVEL = "extractionLevel"
 DOC_METADATA = "metadata"
 DOC_MODIFIED_AT = "modifiedAt"
 DOC_PATH = "path"
 DOC_URL_SUFFIX = "urlSuffix"
 DOC_ROOT_ID = "rootDocument"
 DOC_ROOT_TYPE = "HAS_PARENT"
+DOC_TITLE = "title"
 DOC_COLUMNS = {
     DOC_ID: {NEO4J_CSV_COL: DOC_ID_CSV},
     DOC_DIRNAME: {},
     DOC_CONTENT_TYPE: {},
     DOC_CONTENT_LENGTH: {NEO4J_CSV_COL: "LONG"},
     DOC_EXTRACTION_DATE: {NEO4J_CSV_COL: "DATETIME"},
+    DOC_EXTRACTION_LEVEL: {NEO4J_CSV_COL: "LONG"},
     DOC_METADATA: {},
     DOC_PATH: {},
+    DOC_TITLE: {},
     DOC_URL_SUFFIX: {},
 }
 
@@ -67,7 +71,6 @@ EMAIL_REL_HEADER_FIELDS = "fields"
 EMAIL_REL_COLS = {
     EMAIL_REL_HEADER_FIELDS: {NEO4J_CSV_COL: "STRING[]"},
 }
-
 
 # TODO: check that this list is exhaustive, we know it isn't !!!
 SENT_EMAIL_HEADERS = {"tika_metadata_message_from", "tika_metadata_dc_creator"}

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -354,15 +354,17 @@ async def neo4j_test_session(
 def make_docs(n: int, add_dates: bool = False) -> Generator[Dict, None, None]:
     random.seed(a=777)
     for i in random.sample(list(range(n)), k=n):
+        root = f"doc-{i - 1}" if i else None
         doc = {
             "_index": TEST_PROJECT,
             "_id": f"doc-{i}",
             "_source": {
-                "rootDocument": f"doc-{i - 1}" if i else None,
+                "rootDocument": root,
                 "dirname": f"dirname-{i}",
                 "contentType": f"content-type-{i}",
                 "contentLength": i**2,
                 "extractionDate": "2023-02-06T13:48:22.3866",
+                "extractionLevel": int(bool(root)),
                 "path": f"dirname-{i}",
                 "type": "Document",
                 "join": {"name": "Document"},

--- a/neo4j-app/neo4j_app/tests/core/elasticsearch/test_to_neo4j.py
+++ b/neo4j-app/neo4j_app/tests/core/elasticsearch/test_to_neo4j.py
@@ -1,8 +1,10 @@
-from typing import Optional
+from typing import Dict, Optional
+from urllib.parse import quote_plus
 
 import pytest
 
 from neo4j_app.core.elasticsearch.to_neo4j import (
+    _parse_doc_title,
     es_to_neo4j_doc_row,
     es_to_neo4j_named_entity_row,
 )
@@ -48,3 +50,223 @@ def test_es_to_neo4j_named_entity_row_should_contain_metadata():
     neo4j_row = es_to_neo4j_named_entity_row(es_document)[0]
     # Then
     assert "metadata" in neo4j_row
+
+
+@pytest.mark.parametrize(
+    "source,expected_title",
+    [
+        # Title should be the document ID up to 10 chars when there is nothing else
+        ({}, "doc-id"),
+        # Then it should use the last part of the document path
+        ({"path": "/some/path"}, "path"),
+        ({"path": "/some/path/"}, "doc-id"),
+        # But it should discard empty ones and default to doc ID instead
+        ({"path": "/"}, "doc-id"),
+        ({"path": ""}, "doc-id"),
+        # Then it should use resource name when level > 0
+        (
+            {
+                "path": "/some/path",
+                "metadata": {"tika_metadata_resourcename": "resource-name"},
+                "extractionLevel": 1,
+            },
+            "resource-name",
+        ),
+        (
+            {
+                "path": "/some/path",
+                "metadata": {"tika_metadata_resourcename": "resource-name"},
+                "extractionLevel": 0,
+            },
+            "path",
+        ),
+        (
+            {
+                "path": "/some/path",
+                "metadata": {"tika_metadata_resourcename": "resource-name"},
+            },
+            "path",
+        ),
+        # and trim it
+        (
+            {
+                "path": "/some/path",
+                "metadata": {"tika_metadata_resourcename": " resource-name "},
+                "extractionLevel": 1,
+            },
+            "resource-name",
+        ),
+        # It should also handle URL encoded resource names
+        (
+            {
+                "path": "/some/path",
+                "metadata": {
+                    "tika_metadata_resourcename": f"=?{quote_plus('named=name')}?="
+                },
+                "extractionLevel": 1,
+            },
+            "named=name",
+        ),
+        # But fallback to the doc path when it's empty
+        (
+            {"path": "/some/path", "metadata": {"tika_metadata_resourcename": " "}},
+            "path",
+        ),
+        # Then it should use the doc title
+        (
+            {
+                "path": "/some/path",
+                "metadata": {"tika_metadata_resourcename": "resource-name"},
+                "title": "some-title",
+            },
+            "some-title",
+        ),
+        # But fallback to the doc resource name when it's empty
+        (
+            {
+                "path": "/some/path",
+                "metadata": {"tika_metadata_resourcename": "resource-name"},
+                "title": " ",
+                "extractionLevel": 1,
+            },
+            "resource-name",
+        ),
+        # Then it should use email title for emails
+        (
+            {
+                "path": "/some/path",
+                "title": "some-title",
+                "contentType": "message/some-email-type",
+                "metadata": {"tika_metadata_dc_title": "email-title"},
+            },
+            "email-title",
+        ),
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "application/vnd.ms-outlook",  # outlook content type
+                "metadata": {"tika_metadata_dc_title": "email-title"},
+            },
+            "email-title",
+        ),
+        # and should trim it
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "message/some-email-type",
+                "metadata": {"tika_metadata_dc_title": " email-title "},
+            },
+            "email-title",
+        ),
+        # and should fall back to title when it's empty
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "message/some-email-type",
+                "metadata": {"tika_metadata_dc_title": " "},
+            },
+            "some-title",
+        ),
+        # Then it should use email dc subject
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "message/some-email-type",
+                "metadata": {
+                    "tika_metadata_dc_title": "email-title",
+                    "tika_metadata_dc_subject": "email-dc-subject",
+                },
+            },
+            "email-dc-subject",
+        ),
+        # and fallback to email title when empty
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "message/some-email-type",
+                "metadata": {
+                    "tika_metadata_dc_title": "email-title",
+                    "tika_metadata_dc_subject": " ",
+                },
+            },
+            "email-title",
+        ),
+        # Then it should use email dc subject
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "message/some-email-type",
+                "metadata": {
+                    "tika_metadata_dc_title": "email-title",
+                    "tika_metadata_dc_subject": "email-dc-subject",
+                    "tika_metadata_subject": "email-subject",
+                },
+            },
+            "email-subject",
+        ),
+        # and fallback to email title when empty
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "message/some-email-type",
+                "metadata": {
+                    "tika_metadata_dc_title": "email-title",
+                    "tika_metadata_dc_subject": "email-dc-subject",
+                    "tika_metadata_subject": " ",
+                },
+            },
+            "email-title",
+        ),
+        # then it should use dc title for tweets
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "application/json; twint",
+                "metadata": {
+                    "tika_metadata_dc_title": " tweet-title ",
+                },
+            },
+            "tweet-title",
+        ),
+        # and fallback to title when it's empty
+        (
+            {
+                "path": "/some/path",
+                "tika_metadata_resourcename": "resource-name",
+                "title": "some-title",
+                "contentType": "application/json; twint",
+                "metadata": {
+                    "tika_metadata_dc_title": " ",
+                },
+            },
+            "some-title",
+        ),
+    ],
+)
+def test_parse_doc_title(source: Optional[Dict], expected_title: str):
+    # Given
+    es_document = {
+        "_id": "doc-id",
+        "_index": TEST_PROJECT,
+        "_source": source,
+    }
+    # When
+    title = _parse_doc_title(es_document)  # pylint: disable=protected-access
+    # Then
+    assert title == expected_title

--- a/neo4j-app/neo4j_app/tests/core/test_imports.py
+++ b/neo4j-app/neo4j_app/tests/core/test_imports.py
@@ -514,19 +514,19 @@ async def test_to_neo4j_csvs(
     assert doc_nodes_export.labels == [DOC_NODE]
 
     expected_doc_header = """\
-id:ID(Document),dirname,contentType,contentLength:LONG,extractionDate:DATETIME,path,\
-urlSuffix,createdAt:DATETIME,modifiedAt:DATETIME,:LABEL
+id:ID(Document),dirname,contentType,contentLength:LONG,extractionDate:DATETIME,\
+extractionLevel:LONG,path,title,urlSuffix,createdAt:DATETIME,modifiedAt:DATETIME,:LABEL
 """
     doc_nodes_header_path = archive_dir / doc_nodes_export.header_path
     assert_content(doc_nodes_header_path, expected_doc_header)
 
     expected_doc_nodes = """doc-0,dirname-0,content-type-0,0,2023-02-06T13:48:22.3866,\
-dirname-0,ds/test_project/doc-0/doc-0,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
-doc-1,dirname-1,content-type-1,1,2023-02-06T13:48:22.3866,dirname-1,\
+0,dirname-0,dirname-0,ds/test_project/doc-0/doc-0,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
+doc-1,dirname-1,content-type-1,1,2023-02-06T13:48:22.3866,1,dirname-1,dirname-1,\
 ds/test_project/doc-1/doc-0,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
-doc-3,dirname-3,content-type-3,9,2023-02-06T13:48:22.3866,dirname-3,\
+doc-3,dirname-3,content-type-3,9,2023-02-06T13:48:22.3866,1,dirname-3,dirname-3,\
 ds/test_project/doc-3/doc-2,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
-doc-6,dirname-6,content-type-6,36,2023-02-06T13:48:22.3866,dirname-6,\
+doc-6,dirname-6,content-type-6,36,2023-02-06T13:48:22.3866,1,dirname-6,dirname-6,\
 ds/test_project/doc-6/doc-5,2022-04-08T11:41:34Z,2022-04-08T11:41:34Z,Document
 """
     doc_root_rels_path = archive_dir / doc_nodes_export.node_paths[0]


### PR DESCRIPTION
# PR description

Add title to `Document` nodes.

Document titles are read from ES metadata and  computed similarly as in the [datashare-client `DocumentView`](https://github.com/ICIJ/datashare-client/blob/master/src/pages/DocumentView.vue) and then added to imported document nodes.

 
# Changes
## `neo4j-app`
### Added
- updated the regular and admin imports to add `title` to `Document` nodes