### PR TITLE
fix: worker should not shutdown on fatal error

### DIFF
--- a/neo4j-app/neo4j_app/icij_worker/worker/worker.py
+++ b/neo4j-app/neo4j_app/icij_worker/worker/worker.py
@@ -161,7 +161,6 @@ class Worker(EventPublisher, LogWithNameMixin, AbstractAsyncContextManager, ABC)
             task_error = TaskError.from_exception(fatal_error)
             await self.save_error(error=task_error, task=task, project=project)
             await self.negatively_acknowledge(task, project, requeue=False)
-            raise fatal_error
         self.info('Task(id="%s") successful !', task.id)
 
     @final


### PR DESCRIPTION
# Changes
## `neo4j-app`
### Added
- fixed  a bug where the worker was trying to exit on fatal errors