### PR TITLE
chore: optimize graph stats computation by making them asynchronous

### DIFF
--- a/neo4j-app/neo4j_app/constants.py
+++ b/neo4j-app/neo4j_app/constants.py
@@ -133,6 +133,11 @@ NEO4J_CSV_LABEL = ":LABEL"
 NEO4J_CSV_START_ID = ":START_ID"
 NEO4J_CSV_TYPE = ":TYPE"
 
+STATS_NODE = "_ProjectStatistics"
+STATS_N_DOCS = "nDocuments"
+STATS_N_ENTS = "nEntities"
+STATS_ID = "id"
+
 TASK_NODE = "_Task"
 TASK_COMPLETED_AT = "completedAt"
 TASK_CREATED_AT = "createdAt"

--- a/neo4j-app/neo4j_app/core/elasticsearch/client.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/client.py
@@ -48,7 +48,6 @@ from neo4j_app.core.elasticsearch.utils import (
     SIZE,
     SLICE,
     SORT,
-    SOURCE,
     match_all,
 )
 from neo4j_app.core.neo4j import Neo4jImportWorker, write_neo4j_csv

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -16,44 +16,50 @@ from .migrations.migrations import (
     migration_v_0_5_0_tx,
     migration_v_0_6_0,
     migration_v_0_7_0_tx,
+    migration_v_0_8_0,
 )
 
 V_0_1_0 = Migration(
     version="0.1.0",
-    label="Create migration and project and constraints",
+    label="create migration and project and constraints",
     migration_fn=migration_v_0_1_0_tx,
 )
 V_0_2_0 = Migration(
     version="0.2.0",
-    label="Create doc and named entities index and constraints",
+    label="create doc and named entities index and constraints",
     migration_fn=migration_v_0_2_0_tx,
 )
 V_0_3_0 = Migration(
     version="0.3.0",
-    label="Create tasks indexes and constraints",
+    label="create tasks indexes and constraints",
     migration_fn=migration_v_0_3_0_tx,
 )
 V_0_4_0 = Migration(
     version="0.4.0",
-    label="Create document path and content type indexes",
+    label="create document path and content type indexes",
     migration_fn=migration_v_0_4_0_tx,
 )
 V_0_5_0 = Migration(
     version="0.5.0",
-    label="Create email user and domain indexes",
+    label="create email user and domain indexes",
     migration_fn=migration_v_0_5_0_tx,
 )
 V_0_6_0 = Migration(
     version="0.6.0",
-    label="Add mention counts to named entity document relationships",
+    label="add mention counts to named entity document relationships",
     migration_fn=migration_v_0_6_0,
 )
 V_0_7_0 = Migration(
     version="0.7.0",
-    label="Create document modified and created at indexes",
+    label="create document modified and created at indexes",
     migration_fn=migration_v_0_7_0_tx,
 )
-MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0, V_0_5_0, V_0_6_0, V_0_7_0]
+V_0_8_0 = Migration(
+    version="0.8.0",
+    label="compute project stats and create stats unique constraint",
+    migration_fn=migration_v_0_8_0,
+)
+MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0, V_0_5_0, V_0_6_0, V_0_7_0, V_0_8_0]
 
 
 def get_neo4j_csv_reader(

--- a/neo4j-app/neo4j_app/core/neo4j/graphs.py
+++ b/neo4j-app/neo4j_app/core/neo4j/graphs.py
@@ -1,6 +1,6 @@
 import logging
 from copy import deepcopy
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator, Dict, Optional
 
 import neo4j
 
@@ -14,7 +14,7 @@ from neo4j_app.constants import (
     NE_NODE,
 )
 from neo4j_app.core.neo4j.projects import project_db
-from neo4j_app.core.objects import DumpFormat, GraphCounts
+from neo4j_app.core.objects import DumpFormat, ProjectStatistics
 
 logger = logging.getLogger(__name__)
 
@@ -135,30 +135,66 @@ RETURN cypherStatements;
             yield rec["cypherStatements"]
 
 
-async def count_documents_and_named_entities(
-    neo4j_driver: neo4j.AsyncDriver, project: str, parallel: bool
-) -> GraphCounts:
+async def project_statistics(
+    neo4j_driver: neo4j.AsyncDriver, project: str
+) -> ProjectStatistics:
     neo4j_db = await project_db(neo4j_driver, project)
     async with neo4j_driver.session(database=neo4j_db) as sess:
-        count = await sess.execute_read(
-            _count_documents_and_named_entities_tx, parallel=parallel
-        )
-        return count
+        stats = await sess.execute_read(ProjectStatistics.from_neo4j)
+    return stats
 
 
-async def _count_documents_and_named_entities_tx(
-    tx: neo4j.AsyncTransaction, parallel: bool
-) -> GraphCounts:
-    runtime = "CYPHER runtime=parallel" if parallel else ""
-    doc_query = f"""{runtime}
-MATCH (doc:{DOC_NODE}) RETURN count(*) as nDocs
-"""
+async def refresh_project_statistics(
+    neo4j_driver: neo4j.AsyncDriver, project: str
+) -> ProjectStatistics:
+    neo4j_db = await project_db(neo4j_driver, project)
+    async with neo4j_driver.session(database=neo4j_db) as sess:
+        stats = await sess.execute_write(refresh_project_statistics_tx)
+    return stats
+
+
+async def _count_documents_tx(
+    tx: neo4j.AsyncTransaction, document_counts_key="nDocs"
+) -> int:
+    doc_query = f"""
+    MATCH (doc:{DOC_NODE}) RETURN count(*) as nDocs
+    """
     doc_res = await tx.run(doc_query)
-    entity_query = f"""{runtime}
-MATCH (ne:{NE_NODE})
-WITH DISTINCT labels(ne) as neLabels, ne
+    doc_res = await doc_res.single()
+    n_docs = doc_res[document_counts_key]
+    return n_docs
+
+
+async def _count_entities_tx(
+    tx: neo4j.AsyncTransaction,
+    entity_labels_key: str = "neLabels",
+    entity_counts_key: str = "nMentions",
+) -> Dict[str, int]:
+    entity_query = f"""MATCH (ne:{NE_NODE})
+WITH ne, labels(ne) as neLabels
 MATCH (ne)-[rel:{NE_APPEARS_IN_DOC}]->()
 RETURN neLabels, sum(rel.{NE_MENTION_COUNT}) as nMentions"""
     entity_res = await tx.run(entity_query)
-    count = await GraphCounts.from_neo4j(doc_res=doc_res, entity_res=entity_res)
-    return count
+    n_ents = dict()
+    async for rec in entity_res:
+        labels = [l for l in rec[entity_labels_key] if l != NE_NODE]
+        if len(labels) != 1:
+            msg = (
+                "Expected named entity to have exactly 2 labels."
+                " Refactor this function."
+            )
+            raise ValueError(msg)
+        n_ents[labels[0]] = rec[entity_counts_key]
+    return n_ents
+
+
+async def refresh_project_statistics_tx(
+    tx: neo4j.AsyncTransaction,
+) -> ProjectStatistics:
+    # We could update the stats directly in DB, however since _count_entities_tx needs
+    # to perform advanced error handling, we quickly get back to Python before
+    # re-writing the whole stats
+    n_docs = await _count_documents_tx(tx)
+    n_ents = await _count_entities_tx(tx)
+    stats = await ProjectStatistics.to_neo4j_tx(tx, n_docs, n_ents)
+    return stats

--- a/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
+++ b/neo4j-app/neo4j_app/core/neo4j/migrations/migrate.py
@@ -112,7 +112,7 @@ async def _migrate_with_lock(
     # the DB...
 
     # Lock the DB first, raising in case a migration already exists
-    logger.debug("Trying to run migration %s...", migration.label)
+    logger.debug("Trying to run migration to %s...", migration.label)
     await registry_session.execute_write(
         create_migration_tx,
         project=project,
@@ -120,7 +120,7 @@ async def _migrate_with_lock(
         migration_label=migration.label,
     )
     # Then run to migration
-    logger.debug("Acquired write lock for %s !", migration.label)
+    logger.debug("Acquired write lock to %s !", migration.label)
     sig = signature(migration.migration_fn)
     first_param = list(sig.parameters)[0]
     if first_param == "tx":

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -51,7 +51,6 @@ from neo4j_app.core.utils.pydantic import BaseICIJModel
 from neo4j_app.icij_worker import AsyncApp, WorkerType
 from neo4j_app.icij_worker.typing_ import Dependency
 from neo4j_app.tasks.dependencies import (
-    config_from_path_enter,
     create_project_registry_db_enter,
     es_client_enter,
     es_client_exit,

--- a/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
+++ b/neo4j-app/neo4j_app/tests/core/neo4j/migrations/test_migrations.py
@@ -8,6 +8,7 @@ from neo4j_app.core.neo4j.migrations.migrations import (
     migration_v_0_5_0_tx,
     migration_v_0_6_0,
     migration_v_0_7_0_tx,
+    migration_v_0_8_0,
 )
 
 
@@ -134,3 +135,18 @@ async def test_migration_v_0_7_0_tx(neo4j_test_session: neo4j.AsyncSession):
     ]
     for index in expected_indexes:
         assert index in expected_indexes
+
+
+async def test_migration_v_0_8_0_tx(neo4j_test_session: neo4j.AsyncSession):
+    # When
+    await migration_v_0_8_0(neo4j_test_session)
+    # Then
+    count_query = "MATCH (s:_ProjectStatistics) RETURN count(*) AS nStats"
+    res = await neo4j_test_session.run(count_query)
+    count = await res.single()
+    assert count["nStats"] == 1
+    constraints_res = await neo4j_test_session.run("SHOW CONSTRAINTS")
+    existing_constraints = set()
+    async for rec in constraints_res:
+        existing_constraints.add(rec["name"])
+    assert "constraint_stats_unique_id" in existing_constraints


### PR DESCRIPTION
# PR description

Previously graph statistic computation was perform each time the client was asking for it (each time the project page was loaded).
Graph stats computation has already been optimized in the passed and reached a optimum, while still being too long to be computed on the fly.


The async import pipeline was updated to compute graph counts at the end of the import and stored the count in a singleton neo4j node containing the whole project stats.
	
When the client asks for graph stats, the python backend now just read this singleton node, whic enables to display counts immediatly:

https://github.com/ICIJ/datashare-extension-neo4j/assets/4267202/616de687-7d32-4452-a0dc-283fb58965a2



# Changes

## `neo4j-app`

### Changed
- updated the `full-import` task to refresh graph stats at the end of the import by storing them into a singleton node (the singleton behavior is ensured by enforcing unique constraints, and raising when fetching more than one stats node)
- changed the `GET /graphs/count` to read graph statistics rather than computing them on the fly

### Added
- introduced a `ProjectStatistics` object wrapping the `GraphCounts`, this class will probably contain more information later
- added a migration to add the `_ProjectStatistics` node to old projects
