### PR TITLE
fix: remove useless `:HAS_PARENT` relationship

### DIFF
--- a/neo4j-app/neo4j_app/core/elasticsearch/to_neo4j.py
+++ b/neo4j-app/neo4j_app/core/elasticsearch/to_neo4j.py
@@ -56,7 +56,7 @@ def es_to_neo4j_doc_row(document_hit: Dict) -> List[Dict[str, Any]]:
     hit_source = document_hit[SOURCE]
     doc.update({k: hit_source[k] for k in hit_source if k in DOC_COLUMNS})
     root_id = hit_source.get(DOC_ROOT_ID)
-    if root_id is not None:
+    if root_id is not None and root_id != doc_id:
         doc[DOC_ROOT_ID] = root_id
     doc_url = (
         f"{_DS_DOC_URL}{document_hit[INDEX_]}/{doc_id}/{doc.get(DOC_ROOT_ID, doc_id)}"
@@ -174,12 +174,10 @@ _DOC_ROOT_REL_END_COL = f"{NEO4J_CSV_END_ID}({DOC_NODE})"
 
 
 def es_to_neo4j_doc_root_rel_csv(document_hit: Dict) -> List[Dict[str, str]]:
+    doc_id = document_hit["_id"]
     root_id = document_hit[SOURCE].get(DOC_ROOT_ID)
-    if root_id is not None:
-        rel = {
-            _DOC_ROOT_REL_START_COL: document_hit["_id"],
-            _DOC_ROOT_REL_END_COL: root_id,
-        }
+    if root_id is not None and root_id != doc_id:
+        rel = {_DOC_ROOT_REL_START_COL: doc_id, _DOC_ROOT_REL_END_COL: root_id}
         return [rel]
     return []
 

--- a/neo4j-app/neo4j_app/core/neo4j/__init__.py
+++ b/neo4j-app/neo4j_app/core/neo4j/__init__.py
@@ -17,6 +17,7 @@ from .migrations import (
     migration_v_0_6_0,
     migration_v_0_7_0_tx,
     migration_v_0_8_0,
+    migration_v_0_9_0,
 )
 
 V_0_1_0 = Migration(
@@ -59,7 +60,22 @@ V_0_8_0 = Migration(
     label="compute project stats and create stats unique constraint",
     migration_fn=migration_v_0_8_0,
 )
-MIGRATIONS = [V_0_1_0, V_0_2_0, V_0_3_0, V_0_4_0, V_0_5_0, V_0_6_0, V_0_7_0, V_0_8_0]
+V_0_9_0 = Migration(
+    version="0.9.0",
+    label="delete self parent relationship",
+    migration_fn=migration_v_0_9_0,
+)
+MIGRATIONS = [
+    V_0_1_0,
+    V_0_2_0,
+    V_0_3_0,
+    V_0_4_0,
+    V_0_5_0,
+    V_0_6_0,
+    V_0_7_0,
+    V_0_8_0,
+    V_0_9_0,
+]
 
 
 def get_neo4j_csv_reader(

--- a/neo4j-app/neo4j_app/core/neo4j/documents.py
+++ b/neo4j-app/neo4j_app/core/neo4j/documents.py
@@ -66,6 +66,8 @@ CALL {{
     WITH doc, row
     WHERE doc.{DOC_ID} = row.{DOC_ID} and row.{DOC_ROOT_ID} IS NOT NULL
     MERGE (root:{DOC_NODE} {{{DOC_ID}: row.{DOC_ROOT_ID}}})
+    WITH doc, root
+    WHERE doc <> root
     MERGE (doc)-[:{DOC_ROOT_TYPE}]->(root)
 }} IN TRANSACTIONS OF $batchSize ROWS
 """

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -316,7 +316,7 @@ async def es_test_client() -> AsyncGenerator[ESClient, None]:
 def make_docs(n: int, add_dates: bool = False) -> Generator[Dict, None, None]:
     random.seed(a=777)
     for i in random.sample(list(range(n)), k=n):
-        root = f"doc-{i - 1}" if i else None
+        root = f"doc-{i - 1}" if i else f"doc-{i}"
         doc = {
             "_index": TEST_PROJECT,
             "_id": f"doc-{i}",
@@ -326,7 +326,7 @@ def make_docs(n: int, add_dates: bool = False) -> Generator[Dict, None, None]:
                 "contentType": f"content-type-{i}",
                 "contentLength": i**2,
                 "extractionDate": "2023-02-06T13:48:22.3866",
-                "extractionLevel": int(bool(root)),
+                "extractionLevel": 1 if i else 0,
                 "path": f"dirname-{i}",
                 "type": "Document",
                 "join": {"name": "Document"},


### PR DESCRIPTION
# PR description

Remove the following useless information:
![graph (4)](https://github.com/ICIJ/datashare-extension-neo4j/assets/4267202/d33bc809-5196-494b-a410-2977018ecbb0)


# Changes

## `neo4j-app`
### Changed
- remove `:HAS_PARENT` self loop relationships
