### PR TITLE
fix: broken TRACE import and freeze download button when graph is empty

### DIFF
--- a/neo4j-app/neo4j_app/app/tasks.py
+++ b/neo4j-app/neo4j_app/app/tasks.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 
 from fastapi import APIRouter, HTTPException
-from icij_common.logging_utils import log_elapsed_time_cm
+from icij_common.logging_utils import TRACE, log_elapsed_time_cm
 from icij_worker import (
     Task,
     TaskError,
@@ -40,7 +40,7 @@ def tasks_router() -> APIRouter:
         try:
             await task_manager.enqueue(task, project)
         except TaskAlreadyExists:
-            return Response(task.id, status_code=200)
+            return Response(task.id)
         except TaskQueueIsFull as e:
             raise HTTPException(429, detail="Too Many Requests") from e
         logger.debug("Publishing task queuing event...")

--- a/neo4j-app/neo4j_app/tests/conftest.py
+++ b/neo4j-app/neo4j_app/tests/conftest.py
@@ -45,13 +45,13 @@ from icij_common.test_utils import (  # pylint: disable=unused-import
 )
 from icij_worker import WorkerConfig, WorkerType
 from icij_worker.typing_ import Dependency
-from icij_worker.utils.tests import (
+from icij_worker.utils.tests import (  # pylint: disable=unused-import
     MockEventPublisher,
     MockManager,
     MockWorkerConfig,
     mock_db,
     mock_db_session,
-)  # pylint: disable=unused-import
+)
 from starlette.testclient import TestClient
 
 from neo4j_app.app import ServiceConfig

--- a/plugins/neo4j-graph-widget/components/WidgetNeo4jGraph.vue
+++ b/plugins/neo4j-graph-widget/components/WidgetNeo4jGraph.vue
@@ -86,7 +86,7 @@
               Reset
             </b-button>
             <span id="disabled-wrapper">
-              <b-button ref="submit" type="submit" :disabled="!neo4jAppIsRunning" variant="primary">
+              <b-button ref="submit" type="submit" :disabled="!(neo4jAppIsRunning && projectDocs > 0)" variant="primary">
                 Export graph
               </b-button>
             </span>
@@ -215,6 +215,8 @@ export default {
         return "neo4j extension is starting..."
       } else if (!this.neo4jAppIsRunning) {
         return "neo4j extension is not running, refresh this page to start it or wait "
+      } else if (!this.projectDocs > 0) {
+        return "neo4j graph is empty, create it first to be able to export it !"
       }
       return null
     },
@@ -251,6 +253,9 @@ export default {
     project() {
       return this.$store.state.insights.project
     },
+    projectDocs() {
+      return this.neo4jGraphCounts[this.project]?.documents || 0
+    },
     neo4jAppIsRunning() {
       return this.neo4jAppStatus === AppStatus.Running
     },
@@ -262,6 +267,9 @@ export default {
     },
     neo4jDumpLimit() {
       return this.$store.state.neo4j.neo4jDumpLimit
+    },
+    neo4jGraphCounts() {
+      return this.$store.state.neo4j.neo4jGraphCounts
     }
   },
   methods: {


### PR DESCRIPTION
# Bug description

A user reported that the plugin was not behaving correctly: while the neo4j Python app was running and the graph was not created yet, the export button was available however the create graph button was not

This bug was the combination of a python (missing import button not to be available) and a wrong behavior on the frontend side (export button enabled while the graph is empty)


# Changes

## `neo4j_app`
### Fixed
- fixed missing `TRACE` import 

## `plugin/neo4j-graph-widget`
### Fixed
- display the graph download button only when the graph is available and non empty for the project

