### PR TITLE
fix: sign and notarize MacOS binary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,8 @@ commands:
     parameters:
       branch:
         type: string
+      macos_signing_and_notarization:
+        type: boolean
     steps:
       - checkout-code:
           revision: << parameters.branch >>
@@ -110,7 +112,29 @@ commands:
           command: |
             cd datashare-extension-neo4j
             ./neo4j setup -p neo4j_app
-            ./neo4j build -p neo4j_app --sha >bins/"$(./neo4j binary_name -p neo4j_app)-manifest.txt"
+            ./neo4j build -p neo4j_app
+      - run:
+          name: MacOS signing and notarization
+          when: << parameters.macos_signing_and_notarization >>
+          command: |
+              cargo install apple-codesign
+            
+              echo "$APPSTORE_PRIVATE_KEY_B64" | base64 --decode > /tmp/appstore_private_key.asc
+              echo "$DATASHARE_CA_P12_B64" | base64 --decode > /tmp/datashare_ca.p12
+              
+              rcodesign sign --p12-file /tmp/datashare_ca.p12 --p12-password "$(DATASHARE_CA_PASSWORD)" bins/"$(./neo4j binary_name -p neo4j_app)"
+              
+              # Generate the APP Store Connect API Key
+              rcodesign encode-app-store-connect-api-key -o /tmp/api.json $(APPSTORE_ISSUER_ID) $(APPSTORE_KEY_ID) /tmp/appstore_private_key.asc
+              
+              # Submity the package for notarization and staple it
+              rcodesign notary-submit --api-key-path /tmp/api.json --staple bins/"$(./neo4j binary_name -p neo4j_app)"
+              
+              # Remove keys
+              rm -f /tmp/datashare_ca.p12 /tmp/datashare_ca.crt /tmp/key.json
+      - run:
+          name: Write binary signature to manifest
+          command: ./neo4j sign -p neo4j_app > bins/"$(./neo4j binary_name -p neo4j_app)-manifest.txt"
       # TODO: store_artifacts here if it helps debugging
       - persist_to_workspace:
           root: datashare-extension-neo4j/bins
@@ -188,8 +212,12 @@ jobs:
     steps:
       - checkout-code:
           revision: << parameters.branch >>
+      - run:
+          name: Install cargo
+          command: curl https://sh.rustup.rs -sSf | sh
       - build-python-binary:
           branch: << parameters.branch >>
+          macos_signing_and_notarization: true
 
   build-graph-widget-plugin:
     executor: frontend

--- a/neo4j
+++ b/neo4j
@@ -400,15 +400,8 @@ function _commands() {
 
     function build() {
         if _should_run_project "neo4j_app"; then
-            if [ -z "$PRINT_SHA" ]; then _print_step "Building Python app executable"; fi
+            _print_step "Building Python app executable"
             _build_neo4j_app
-            if [ -n "$PRINT_SHA" ]; then
-                # TODO: to avoid this, we could redirect logs from _build_neo4j_app to stderr and echo the bin path
-                #  to stdout
-                local bin_path
-                bin_path="bins/$(_make_neoj_binary_name)"
-                shasum -a 256 "$bin_path"
-            fi
         elif _should_run_project "neo4j_extension"; then
             _print_step "Compiling the java extension"
             cd "$ROOT_DIR"
@@ -607,6 +600,16 @@ Please run ./neo4j format"
             yarn install --immutable
         else
             _exit_with_message "Can't setup project $PROJECT"
+        fi
+    }
+
+    function sign() {
+        if _should_run_project "neo4j_app"; then
+            local bin_path
+            bin_path="bins/$(_make_neoj_binary_name)"
+            shasum -a 256 "$bin_path"
+        else
+            _exit_with_message "Can't sign project $PROJECT"
         fi
     }
 


### PR DESCRIPTION
# Bug description

Following #172 is seems that MacOS 10.15 requires binaries to be signed and notarized

# Changes
## `.circleci`
### Fixed
- sign and notarize python binary on macos
